### PR TITLE
memory: use Map instead of plain objects for directories

### DIFF
--- a/packages/memory/src/memory-fs.ts
+++ b/packages/memory/src/memory-fs.ts
@@ -39,7 +39,7 @@ export function createBaseMemoryFs(): IBaseFileSystem {
     return { ...syncMemFs, ...syncToAsyncFs(syncMemFs) }
 }
 
-// ugly workaround for webpack's polyfilled path not implementing posix
+// ugly workaround for webpack's polyfilled path not implementing `.posix` field
 // TODO: inline path-posix implementation taked from latest node's source (faster!)
 const posixPath = pathMain.posix as typeof pathMain || pathMain
 
@@ -237,10 +237,10 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
         const resolvedPath = resolvePath(nodePath)
         const splitPath = resolvedPath.split(posixPath.sep)
 
-        return splitPath.reduce((prevNode: IFsMemDirectoryNode | IFsMemFileNode | null, depthName: string) => {
+        return splitPath.reduce((fsNode: IFsMemDirectoryNode | IFsMemFileNode | null, depthName: string) => {
             return (depthName === '' || depthName === '.') ?
-                prevNode :
-                (prevNode && prevNode.type === 'dir' && prevNode.contents.get(depthName.toLowerCase())) || null
+                fsNode :
+                (fsNode && fsNode.type === 'dir' && fsNode.contents.get(depthName.toLowerCase())) || null
         }, root)
     }
 

--- a/packages/memory/src/memory-fs.ts
+++ b/packages/memory/src/memory-fs.ts
@@ -50,11 +50,12 @@ const posixPath = pathMain.posix as typeof pathMain || pathMain
 export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
     const root: IFsMemDirectoryNode = createMemDirectory('memory-fs-root')
     const pathListeners = new SetMultiMap<string, WatchEventListener>()
-    const globalListeners: Set<WatchEventListener> = new Set()
+    const globalListeners = new Set<WatchEventListener>()
+    const resolvePath = posixPath.resolve.bind(null, '/')
 
     return {
         root,
-        path: posixPath,
+        path: { ...posixPath, resolve: resolvePath },
         watchService: {
             async watchPath(path, listener) {
                 if (listener) {
@@ -127,11 +128,11 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
 
         const fileName = posixPath.basename(filePath)
         const lowerCaseFileName = fileName.toLowerCase()
-        const fileNode = parentNode.contents[lowerCaseFileName]
+        const fileNode = parentNode.contents.get(lowerCaseFileName)
 
         if (!fileNode) {
             const newFileNode = createMemFile(fileName, fileContent, encoding)
-            parentNode.contents[lowerCaseFileName] = newFileNode
+            parentNode.contents.set(lowerCaseFileName, newFileNode)
             emitWatchEvent({ path: filePath, stats: createStatsFromNode(newFileNode) })
         } else if (fileNode.type === 'file') {
             updateMemFile(fileNode, fileContent, encoding)
@@ -151,7 +152,7 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
 
         const fileName = posixPath.basename(filePath)
         const lowerCaseFileName = fileName.toLowerCase()
-        const fileNode = parentNode.contents[lowerCaseFileName]
+        const fileNode = parentNode.contents.get(lowerCaseFileName)
 
         if (!fileNode) {
             throw new Error(`${filePath} ${FsErrorCodes.NO_FILE}`)
@@ -159,7 +160,7 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
             throw new Error(`${filePath} ${FsErrorCodes.PATH_IS_DIRECTORY}`)
         }
 
-        delete parentNode.contents[lowerCaseFileName]
+        parentNode.contents.delete(lowerCaseFileName)
         emitWatchEvent({ path: filePath, stats: null })
     }
 
@@ -172,7 +173,7 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
             throw new Error(`${directoryPath} ${FsErrorCodes.PATH_IS_FILE}`)
         }
 
-        return Object.keys(directoryNode.contents).map(lowerCaseName => directoryNode.contents[lowerCaseName].name)
+        return Array.from(directoryNode.contents.values()).map(({ name }) => name)
     }
 
     function mkdirSync(directoryPath: string): void {
@@ -185,14 +186,14 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
 
         const directoryName = posixPath.basename(directoryPath)
         const lowerCaseDirectoryName = directoryName.toLowerCase()
-        const currentNode = parentNode.contents[lowerCaseDirectoryName]
+        const currentNode = parentNode.contents.get(lowerCaseDirectoryName)
 
         if (currentNode) {
             throw new Error(`${directoryPath} ${FsErrorCodes.PATH_ALREADY_EXISTS}`)
         }
 
-        const newDirNode: IFsMemDirectoryNode = createMemDirectory(directoryName, parentNode)
-        parentNode.contents[lowerCaseDirectoryName] = newDirNode
+        const newDirNode: IFsMemDirectoryNode = createMemDirectory(directoryName)
+        parentNode.contents.set(lowerCaseDirectoryName, newDirNode)
 
         emitWatchEvent({ path: directoryPath, stats: createStatsFromNode(newDirNode) })
     }
@@ -207,15 +208,15 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
 
         const directoryName = posixPath.basename(directoryPath)
         const lowerCaseDirectoryName = directoryName.toLowerCase()
-        const directoryNode = parentNode.contents[lowerCaseDirectoryName]
+        const directoryNode = parentNode.contents.get(lowerCaseDirectoryName)
 
         if (!directoryNode || directoryNode.type !== 'dir') {
             throw new Error(`${directoryPath} ${FsErrorCodes.NO_DIRECTORY}`)
-        } else if (Object.keys(directoryNode.contents).length > 0) {
+        } else if (directoryNode.contents.size > 0) {
             throw new Error(`${directoryPath} ${FsErrorCodes.DIRECTORY_NOT_EMPTY}`)
         }
 
-        delete parentNode.contents[lowerCaseDirectoryName]
+        parentNode.contents.delete(lowerCaseDirectoryName)
         emitWatchEvent({ path: directoryPath, stats: null })
     }
 
@@ -233,12 +234,13 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
     }
 
     function getNode(nodePath: string): IFsMemFileNode | IFsMemDirectoryNode | null {
-        const normalizedPath = posixPath.normalize(nodePath)
-        const splitPath = normalizedPath.split(posixPath.sep)
+        const resolvedPath = resolvePath(nodePath)
+        const splitPath = resolvedPath.split(posixPath.sep)
 
         return splitPath.reduce((prevNode: IFsMemDirectoryNode | IFsMemFileNode | null, depthName: string) => {
-            return (prevNode && prevNode.type === 'dir' &&
-                prevNode.contents[depthName.toLowerCase()]) || null
+            return (depthName === '' || depthName === '.') ?
+                prevNode :
+                (prevNode && prevNode.type === 'dir' && prevNode.contents.get(depthName.toLowerCase())) || null
         }, root)
     }
 
@@ -264,7 +266,7 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
 
         const sourceName = posixPath.basename(sourcePath)
         const lowerCaseSourceName = sourceName.toLowerCase()
-        const sourceNode = sourceParentNode.contents[lowerCaseSourceName]
+        const sourceNode = sourceParentNode.contents.get(lowerCaseSourceName)
 
         if (!sourceNode) {
             throw new Error(`${sourcePath} ${FsErrorCodes.NO_FILE_OR_DIRECTORY}`)
@@ -279,11 +281,11 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
 
         const destinationName = posixPath.basename(destinationPath)
         const lowerCaseDestinationName = destinationName.toLowerCase()
-        const destinationNode = destinationParentNode.contents[lowerCaseDestinationName]
+        const destinationNode = destinationParentNode.contents.get(lowerCaseDestinationName)
 
         if (destinationNode) {
             if (destinationNode.type === 'dir') {
-                if (Object.keys(destinationNode.contents).length > 0) {
+                if (destinationNode.contents.size > 0) {
                     throw new Error(`${destinationPath} ${FsErrorCodes.DIRECTORY_NOT_EMPTY}`)
                 }
             } else {
@@ -291,14 +293,10 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
             }
         }
 
-        delete sourceParentNode.contents[lowerCaseSourceName]
+        sourceParentNode.contents.delete(lowerCaseSourceName)
         sourceNode.name = destinationName
         sourceNode.mtime = new Date()
-        if (sourceNode.type === 'dir') {
-            // Shadow (non-listed) entries such as ".." reside in directory nodes' prototypes
-            Object.getPrototypeOf(sourceNode.contents)['..'] = destinationParentNode
-        }
-        destinationParentNode.contents[lowerCaseDestinationName] = sourceNode
+        destinationParentNode.contents.set(lowerCaseDestinationName, sourceNode)
 
         emitWatchEvent({ path: sourcePath, stats: null })
         emitWatchEvent({ path: destinationPath, stats: createStatsFromNode(sourceNode) })
@@ -324,7 +322,7 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
 
         const targetName = posixPath.basename(destinationPath)
         const lowerCaseTargetName = targetName.toLowerCase()
-        const destinationFileNode = destParentNode.contents[lowerCaseTargetName]
+        const destinationFileNode = destParentNode.contents.get(lowerCaseTargetName)
 
         if (destinationFileNode) {
             const shouldOverride = !(flags & FileSystemConstants.COPYFILE_EXCL) // tslint:disable-line no-bitwise
@@ -338,29 +336,21 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
             }
         }
 
-        const newFileNode = {...sourceFileNode, name : targetName, mtime: new Date()}
-        destParentNode.contents[lowerCaseTargetName] = newFileNode
+        const newFileNode: IFsMemFileNode = { ...sourceFileNode, name: targetName, mtime: new Date() }
+        destParentNode.contents.set(lowerCaseTargetName, newFileNode)
         emitWatchEvent({ path: destinationPath, stats: createStatsFromNode(newFileNode) })
     }
 }
 
-function createMemDirectory(name: string, parent?: IFsMemDirectoryNode): IFsMemDirectoryNode {
-    const shadowEntries = Object.create(null)
-    const actualEntries = Object.create(shadowEntries)
+function createMemDirectory(name: string): IFsMemDirectoryNode {
     const currentDate = new Date()
-    const memDirectory: IFsMemDirectoryNode = {
+    return {
         type: 'dir',
         name,
-        contents: actualEntries,
+        contents: new Map(),
         birthtime: currentDate,
         mtime: currentDate
     }
-
-    shadowEntries['.'] = shadowEntries[''] = memDirectory
-    if (parent) {
-        shadowEntries['..'] = parent
-    }
-    return memDirectory
 }
 
 function createMemFile(name: string, content: string | Buffer, encoding?: string): IFsMemFileNode {
@@ -373,11 +363,9 @@ function createMemFile(name: string, content: string | Buffer, encoding?: string
         mtime: currentDate
     }
 
-    const newFileNode: IFsMemFileNode = typeof content === 'string' ?
+    return typeof content === 'string' ?
         { ...partialNode, contents: content, rawContents: Buffer.from(content, encoding) } :
         { ...partialNode, rawContents: content }
-
-    return newFileNode
 }
 
 function updateMemFile(fileNode: IFsMemFileNode, content: string | Buffer, encoding?: string): void {

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -19,5 +19,5 @@ export interface IFsMemFileNode extends IFsMemNode {
 
 export interface IFsMemDirectoryNode extends IFsMemNode {
     type: 'dir'
-    contents: { [nodeName: string]: IFsMemDirectoryNode | IFsMemFileNode }
+    contents: Map<string, IFsMemDirectoryNode | IFsMemFileNode>
 }

--- a/packages/memory/test/memory-fs.spec.ts
+++ b/packages/memory/test/memory-fs.spec.ts
@@ -2,7 +2,6 @@ import { syncBaseFsContract, asyncBaseFsContract, syncFsContract, asyncFsContrac
 import { createMemoryFs } from '../src'
 import { expect } from 'chai'
 import { sleep } from 'promise-assist'
-import { IFileSystem } from '@file-services/types'
 
 describe('In-memory File System Implementation', () => {
     const testProvider = async () => {
@@ -35,14 +34,13 @@ describe('In-memory File System Implementation', () => {
         const sourceFilePath = '/file.txt'
         const emptyDirectoryPath = '/empty_dir'
 
-        let fs: IFileSystem
-
-        beforeEach(async () => fs = createMemoryFs({
+        const createPopulatedFs = () => createMemoryFs({
             [sourceFilePath]: 'test content',
             [emptyDirectoryPath]: {}
-        }))
+        })
 
         it('preserves birthtime and updates mtime', async () => {
+            const fs = createPopulatedFs()
             const sourceFileStats = fs.statSync(sourceFilePath)
             const destFilePath = fs.path.join(emptyDirectoryPath, 'dest')
 
@@ -57,10 +55,14 @@ describe('In-memory File System Implementation', () => {
         })
 
         it('fails if source is a directory', () => {
+            const fs = createPopulatedFs()
+
             expect(() => fs.copyFileSync(emptyDirectoryPath, '/some_other_folder')).to.throw('EISDIR')
         })
 
         it('fails if target is a directory', () => {
+            const fs = createPopulatedFs()
+
             expect(() => fs.copyFileSync(sourceFilePath, emptyDirectoryPath)).to.throw('EISDIR')
         })
     })

--- a/packages/memory/test/memory-fs.spec.ts
+++ b/packages/memory/test/memory-fs.spec.ts
@@ -45,8 +45,8 @@ describe('In-memory File System Implementation', () => {
         it('preserves birthtime and updates mtime', async () => {
             const sourceFileStats = fs.statSync(sourceFilePath)
             const destFilePath = fs.path.join(emptyDirectoryPath, 'dest')
-            // postpone copying for 1s to make sure timestamps can be different
-            await sleep(100)
+
+            await sleep(100) // postpone copying to ensure timestamps are different
 
             fs.copyFileSync(sourceFilePath, destFilePath)
 


### PR DESCRIPTION
- better performance, with us deleting keys off the object (deoptimizing it)
- removed confusing shadow entries concept for easier node management
- ensure path.resolve is relative to `/` instead of cwd in node
- removed unneeded async copy mtime tests. sync is enough in this case.
- simplified copying tests. IDirectoryContents accepts absolute paths and treats them properly. less let statements.