### PR TITLE
test-kit: change WatchEventsValidator::lastEvent to accept multiple events

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -10,7 +10,7 @@
     "lint": "run-p lint:src lint:test",
     "lint:src": "tslint --project src",
     "lint:test": "tslint --project test",
-    "test": "mocha -r @ts-tools/node/r \"test/**/*.spec.ts?(x)\" --watch-extensions ts,tsx --colors --timeout 5000",
+    "test": "mocha -r @ts-tools/node/r \"test/**/*.spec.ts?(x)\" --watch-extensions ts,tsx --colors --timeout 10000",
     "prepack": "yarn build"
   },
   "dependencies": {

--- a/packages/node/test/node-fs.spec.ts
+++ b/packages/node/test/node-fs.spec.ts
@@ -32,4 +32,4 @@ describe('Node File System Implementation', () => {
     asyncFsContract(testProvider)
     syncFsContract(testProvider)
 
-}).timeout(5000) // increase timeout to 5s, as local file operations are slower (especially in CI)
+})

--- a/packages/node/test/watch-service.spec.ts
+++ b/packages/node/test/watch-service.spec.ts
@@ -22,12 +22,12 @@ describe('Node Watch Service', function() {
     })
 
     describe('watching files', () => {
-        let validate: WatchEventsValidator
+        let validator: WatchEventsValidator
         let testFilePath: string
 
         beforeEach('create temp fixture file and intialize watch service', async () => {
             watchService = new NodeWatchService()
-            validate = new WatchEventsValidator(watchService)
+            validator = new WatchEventsValidator(watchService)
 
             tempDir = await createTempDirectory()
             testFilePath = join(tempDir.path, 'test-file')
@@ -41,8 +41,8 @@ describe('Node Watch Service', function() {
             await writeFile(testFilePath, SAMPLE_CONTENT)
             await writeFile(testFilePath, SAMPLE_CONTENT)
 
-            await validate.lastEvent({ path: testFilePath, stats: await stat(testFilePath) })
-            await validate.noMoreEvents()
+            await validator.validateEvents([{ path: testFilePath, stats: await stat(testFilePath) }])
+            await validator.noMoreEvents()
         })
 
         it('emits two different watch events when changes are >200ms appart', async () => {
@@ -53,21 +53,23 @@ describe('Node Watch Service', function() {
 
             await writeFile(testFilePath, SAMPLE_CONTENT)
 
-            const secondStats = await stat(testFilePath)
+            const secondWriteStats = await stat(testFilePath)
 
-            await validate.lastEvent({ path: testFilePath, stats: firstWriteStats })
-            await validate.lastEvent({ path: testFilePath, stats: secondStats })
-            await validate.noMoreEvents()
+            await validator.validateEvents([
+                { path: testFilePath, stats: firstWriteStats },
+                { path: testFilePath, stats: secondWriteStats }
+            ])
+            await validator.noMoreEvents()
         })
     })
 
     describe('watching directories', () => {
-        let validate: WatchEventsValidator
+        let validator: WatchEventsValidator
         let testDirectoryPath: string
 
         beforeEach('create temp fixture directory and intialize watch service', async () => {
             watchService = new NodeWatchService()
-            validate = new WatchEventsValidator(watchService)
+            validator = new WatchEventsValidator(watchService)
 
             tempDir = await createTempDirectory()
             testDirectoryPath = join(tempDir.path, 'test-directory')
@@ -80,19 +82,19 @@ describe('Node Watch Service', function() {
 
             await rmdir(testDirectoryPath)
 
-            await validate.lastEvent({ path: testDirectoryPath, stats: null })
-            await validate.noMoreEvents()
+            await validator.validateEvents([{ path: testDirectoryPath, stats: null }])
+            await validator.noMoreEvents()
         })
     })
 
     describe('mixing watch of directories and files', () => {
-        let validate: WatchEventsValidator
+        let validator: WatchEventsValidator
         let testDirectoryPath: string
         let testFilePath: string
 
         beforeEach('create temp fixture directory and intialize watch service', async () => {
             watchService = new NodeWatchService()
-            validate = new WatchEventsValidator(watchService)
+            validator = new WatchEventsValidator(watchService)
 
             tempDir = await createTempDirectory()
             testDirectoryPath = join(tempDir.path, 'test-directory')
@@ -107,8 +109,8 @@ describe('Node Watch Service', function() {
 
             await writeFile(testFilePath, SAMPLE_CONTENT)
 
-            await validate.lastEvent({ path: testFilePath, stats: await stat(testFilePath) })
-            await validate.noMoreEvents()
+            await validator.validateEvents([{ path: testFilePath, stats: await stat(testFilePath) }])
+            await validator.noMoreEvents()
         })
 
         it('allows watching in any order', async () => {
@@ -117,8 +119,8 @@ describe('Node Watch Service', function() {
 
             await writeFile(testFilePath, SAMPLE_CONTENT)
 
-            await validate.lastEvent({ path: testFilePath, stats: await stat(testFilePath) })
-            await validate.noMoreEvents()
+            await validator.validateEvents([{ path: testFilePath, stats: await stat(testFilePath) }])
+            await validator.noMoreEvents()
         })
     })
 })

--- a/packages/test-kit/src/async-base-fs-contract.ts
+++ b/packages/test-kit/src/async-base-fs-contract.ts
@@ -114,12 +114,12 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         describe('watching files', function() {
             this.timeout(10000)
 
-            let validate: WatchEventsValidator
+            let validator: WatchEventsValidator
             let testFilePath: string
 
             beforeEach('create temp fixture file and intialize validator', async () => {
                 const { fs, tempDirectoryPath, fs: { path, watchService } } = testInput
-                validate = new WatchEventsValidator(watchService)
+                validator = new WatchEventsValidator(watchService)
 
                 testFilePath = path.join(tempDirectoryPath, 'test-file')
 
@@ -132,8 +132,8 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
                 await fs.writeFile(testFilePath, DIFFERENT_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: await fs.stat(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.noMoreEvents()
             })
 
             it('emits watch event when a watched file is removed', async () => {
@@ -141,8 +141,8 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
                 await fs.unlink(testFilePath)
 
-                await validate.lastEvent({ path: testFilePath, stats: null })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: null }])
+                await validator.noMoreEvents()
             })
 
             it('keeps watching if file is deleted and recreated immediately', async () => {
@@ -152,12 +152,12 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 await fs.unlink(testFilePath)
                 await fs.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: await fs.stat(testFilePath) })
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
 
                 await fs.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: await fs.stat(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.noMoreEvents()
             })
         })
 
@@ -273,12 +273,12 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         describe('watching directories', function() {
             this.timeout(10000)
 
-            let validate: WatchEventsValidator
+            let validator: WatchEventsValidator
             let testDirectoryPath: string
 
             beforeEach('create temp fixture directory and intialize validator', async () => {
                 const { fs, tempDirectoryPath, fs: { path, watchService } } = testInput
-                validate = new WatchEventsValidator(watchService)
+                validator = new WatchEventsValidator(watchService)
 
                 testDirectoryPath = path.join(tempDirectoryPath, 'test-directory')
                 await fs.mkdir(testDirectoryPath)
@@ -292,8 +292,8 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 const testFilePath = path.join(testDirectoryPath, 'test-file')
                 await fs.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: await fs.stat(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.noMoreEvents()
             })
 
             it('fires a watch event when a file is changed inside inside a watched directory', async () => {
@@ -305,8 +305,8 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
                 await fs.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: await fs.stat(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.noMoreEvents()
             })
 
             it('fires a watch event when a file is removed inside inside a watched directory', async () => {
@@ -318,21 +318,21 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
                 await fs.unlink(testFilePath)
 
-                await validate.lastEvent({ path: testFilePath, stats: null })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: null }])
+                await validator.noMoreEvents()
             })
         })
 
         describe('watching both directories and files', function() {
             this.timeout(10000)
 
-            let validate: WatchEventsValidator
+            let validator: WatchEventsValidator
             let testDirectoryPath: string
             let testFilePath: string
 
             beforeEach('create temp fixture directory and intialize watch service', async () => {
                 const { fs, tempDirectoryPath, fs: { path, watchService } } = testInput
-                validate = new WatchEventsValidator(watchService)
+                validator = new WatchEventsValidator(watchService)
 
                 testDirectoryPath = path.join(tempDirectoryPath, 'test-directory')
                 await fs.mkdir(testDirectoryPath)
@@ -348,8 +348,8 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
                 await fs.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: await fs.stat(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.noMoreEvents()
             })
 
             it('allows watching in any order', async () => {
@@ -360,8 +360,8 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
                 await fs.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: await fs.stat(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.noMoreEvents()
             })
         })
 

--- a/packages/test-kit/src/sync-base-fs-contract.ts
+++ b/packages/test-kit/src/sync-base-fs-contract.ts
@@ -129,13 +129,13 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
         describe('watching files', function() {
             this.timeout(10000)
 
-            let validate: WatchEventsValidator
+            let validator: WatchEventsValidator
             let testFilePath: string
 
             beforeEach('create temp fixture file and intialize validator', async () => {
                 const { fs, tempDirectoryPath } = testInput
                 const { watchService, path } = fs
-                validate = new WatchEventsValidator(watchService)
+                validator = new WatchEventsValidator(watchService)
 
                 testFilePath = path.join(tempDirectoryPath, 'test-file')
 
@@ -148,8 +148,8 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
 
                 fs.writeFileSync(testFilePath, DIFFERENT_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: fs.statSync(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: fs.statSync(testFilePath) }])
+                await validator.noMoreEvents()
             })
 
             it('emits watch event when a watched file is removed', async () => {
@@ -157,8 +157,8 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
 
                 fs.unlinkSync(testFilePath)
 
-                await validate.lastEvent({ path: testFilePath, stats: null })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: null }])
+                await validator.noMoreEvents()
             })
 
             it('keeps watching if file is deleted and recreated immediately', async () => {
@@ -168,12 +168,12 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
                 fs.unlinkSync(testFilePath)
                 fs.writeFileSync(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: fs.statSync(testFilePath) })
+                await validator.validateEvents([{ path: testFilePath, stats: fs.statSync(testFilePath) }])
 
                 fs.writeFileSync(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: fs.statSync(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: fs.statSync(testFilePath) }])
+                await validator.noMoreEvents()
             })
         })
 
@@ -310,13 +310,13 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
         describe('watching directories', function() {
             this.timeout(10000)
 
-            let validate: WatchEventsValidator
+            let validator: WatchEventsValidator
             let testDirectoryPath: string
 
             beforeEach('create temp fixture directory and intialize validator', async () => {
                 const { fs, tempDirectoryPath } = testInput
                 const { watchService, path } = fs
-                validate = new WatchEventsValidator(watchService)
+                validator = new WatchEventsValidator(watchService)
 
                 testDirectoryPath = path.join(tempDirectoryPath, 'test-directory')
                 fs.mkdirSync(testDirectoryPath)
@@ -331,8 +331,8 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
                 const testFilePath = path.join(testDirectoryPath, 'test-file')
                 fs.writeFileSync(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: fs.statSync(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: fs.statSync(testFilePath) }])
+                await validator.noMoreEvents()
             })
 
             it('fires a watch event when a file is changed inside inside a watched directory', async () => {
@@ -345,8 +345,8 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
 
                 fs.writeFileSync(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: fs.statSync(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: fs.statSync(testFilePath) }])
+                await validator.noMoreEvents()
             })
 
             it('fires a watch event when a file is removed inside inside a watched directory', async () => {
@@ -359,22 +359,22 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
 
                 fs.unlinkSync(testFilePath)
 
-                await validate.lastEvent({ path: testFilePath, stats: null })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: null }])
+                await validator.noMoreEvents()
             })
         })
 
         describe('watching both directories and files', function() {
             this.timeout(10000)
 
-            let validate: WatchEventsValidator
+            let validator: WatchEventsValidator
             let testDirectoryPath: string
             let testFilePath: string
 
             beforeEach('create temp fixture directory and intialize watchService', async () => {
                 const { fs, tempDirectoryPath } = testInput
                 const { watchService, path } = fs
-                validate = new WatchEventsValidator(watchService)
+                validator = new WatchEventsValidator(watchService)
 
                 testDirectoryPath = path.join(tempDirectoryPath, 'test-directory')
                 fs.mkdirSync(testDirectoryPath)
@@ -391,8 +391,8 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
 
                 fs.writeFileSync(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: fs.statSync(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: fs.statSync(testFilePath) }])
+                await validator.noMoreEvents()
             })
 
             it('allows watching in any order', async () => {
@@ -404,8 +404,8 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
 
                 fs.writeFileSync(testFilePath, SAMPLE_CONTENT)
 
-                await validate.lastEvent({ path: testFilePath, stats: fs.statSync(testFilePath) })
-                await validate.noMoreEvents()
+                await validator.validateEvents([{ path: testFilePath, stats: fs.statSync(testFilePath) }])
+                await validator.noMoreEvents()
             })
         })
 

--- a/packages/test-kit/src/watch-events-validator.ts
+++ b/packages/test-kit/src/watch-events-validator.ts
@@ -4,11 +4,11 @@ import { IWatchEvent, IWatchService } from '@file-services/types'
 
 export interface IWatchEventValidatorOptions {
     /**
-     * Timeout (in ms) to wait for each event.
+     * Timeout (in ms) for each `validateEvents` call.
      *
      * @default 5000
      */
-    singleEventTimeout?: number
+    validateTimeout?: number
 
     /**
      * Timeout (in ms) to wait before checking for no additional events.
@@ -26,7 +26,7 @@ export class WatchEventsValidator {
     private options: Required<IWatchEventValidatorOptions>
 
     constructor(private watchService: IWatchService, options?: IWatchEventValidatorOptions) {
-        this.options = { singleEventTimeout: 5000, noMoreEventsTimeout: 500, ...options }
+        this.options = { validateTimeout: 5000, noMoreEventsTimeout: 500, ...options }
 
         this.watchService.addGlobalListener(e => this.capturedEvents.push(e))
     }
@@ -42,7 +42,7 @@ export class WatchEventsValidator {
         await waitFor(() => {
             const actual = capturedEvents.slice(-1 * expectedEvents.length).map(simplifyEvent)
             expect(actual).to.eql(expected)
-        }, { timeout: this.options.singleEventTimeout, delay: 100 })
+        }, { timeout: this.options.validateTimeout, delay: 100 })
 
         this.capturedEvents.length = 0
     }


### PR DESCRIPTION
should fix CI flakiness around ">200ms" watch service test, as both events are now verified together, instead of trying to catch the first one before the second arrives.