### PR TITLE
Breaking: change API to be a real subset of Node's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ os:
 node_js:
   - 11 # current
   - 10 # lts
-  - 8
 
 cache:
   yarn: true

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^5.2.6",
-    "@types/node": "8",
+    "@types/node": "10",
     "@types/react": "^16.8.7",
     "@types/react-dom": "^16.8.2",
     "@types/rimraf": "^2.0.2",

--- a/packages/memory/src/memory-fs.ts
+++ b/packages/memory/src/memory-fs.ts
@@ -102,6 +102,9 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
         readdirSync,
         readFileSync,
         realpathSync: p => p, // links are not implemented yet
+        readlinkSync: () => {
+            throw new Error('links are not implemented yet')
+        },
         renameSync,
         rmdirSync,
         statSync,

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -15,8 +15,7 @@
   },
   "dependencies": {
     "@file-services/types": "^0.4.11",
-    "@file-services/utils": "^0.4.11",
-    "proper-fs": "^1.1.2"
+    "@file-services/utils": "^0.4.11"
   },
   "files": [
     "cjs",
@@ -24,7 +23,7 @@
     "!src/tsconfig.json"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/node",

--- a/packages/node/src/node-fs.ts
+++ b/packages/node/src/node-fs.ts
@@ -1,35 +1,14 @@
 import path from 'path'
 import { chdir, cwd } from 'process'
-import {
-    lstat,
-    lstatSync,
-    mkdir,
-    mkdirSync,
-    readdir,
-    readdirSync,
-    readFile,
-    readFileSync,
-    realpath,
-    realpathSync,
-    rename,
-    renameSync,
-    rmdir,
-    rmdirSync,
-    stat,
-    statSync,
-    unlink,
-    unlinkSync,
-    writeFile,
-    writeFileSync,
-    isCaseSensitive,
-    copyFile,
-    copyFileSync,
-    exists,
-    existsSync
-} from 'proper-fs'
+import fs from 'fs'
+
 import { createAsyncFileSystem, createSyncFileSystem } from '@file-services/utils'
 import { IBaseFileSystem, IFileSystem } from '@file-services/types'
 import { NodeWatchService, INodeWatchServiceOptions } from './watch-service'
+
+const {promises, existsSync} = fs
+
+const caseSensitive = !existsSync(__filename.toUpperCase())
 
 export interface ICreateNodeFsOptions {
     watchOptions?: INodeWatchServiceOptions
@@ -50,31 +29,9 @@ export function createBaseNodeFs(options?: ICreateNodeFsOptions): IBaseFileSyste
         watchService: new NodeWatchService(options && options.watchOptions),
         chdir,
         cwd,
-        caseSensitive: isCaseSensitive,
-        copyFile,
-        copyFileSync,
-        exists,
-        existsSync,
-        lstat,
-        lstatSync,
-        mkdir,
-        mkdirSync,
-        readdir,
-        readdirSync,
-        readFile,
-        readFileSync,
-        realpath,
-        realpathSync,
-        rename,
-        renameSync,
-        rmdir,
-        rmdirSync,
-        stat,
-        statSync,
-        unlink,
-        unlinkSync,
-        writeFile,
-        writeFileSync
+        caseSensitive,
+        ...fs,
+        ...promises
     }
 }
 

--- a/packages/node/src/node-fs.ts
+++ b/packages/node/src/node-fs.ts
@@ -27,13 +27,15 @@ export function createNodeFs(options?: ICreateNodeFsOptions): IFileSystem {
 export function createBaseNodeFs(options?: ICreateNodeFsOptions): IBaseFileSystem {
     return {
         path,
-        watchService: new NodeWatchService(options && options.watchOptions),
         chdir,
         cwd,
+        watchService: new NodeWatchService(options && options.watchOptions),
         caseSensitive,
         ...fs,
-        ...promises,
-        exists: promisify(exists)
+        promises: {
+            ...promises,
+            exists: promisify(exists)
+        }
     }
 }
 

--- a/packages/node/src/node-fs.ts
+++ b/packages/node/src/node-fs.ts
@@ -6,7 +6,7 @@ import { createAsyncFileSystem, createSyncFileSystem } from '@file-services/util
 import { IBaseFileSystem, IFileSystem } from '@file-services/types'
 import { NodeWatchService, INodeWatchServiceOptions } from './watch-service'
 
-const {promises, existsSync} = fs
+const { promises, existsSync } = fs
 
 const caseSensitive = !existsSync(__filename.toUpperCase())
 

--- a/packages/node/src/node-fs.ts
+++ b/packages/node/src/node-fs.ts
@@ -7,7 +7,7 @@ import { createAsyncFileSystem, createSyncFileSystem } from '@file-services/util
 import { IBaseFileSystem, IFileSystem } from '@file-services/types'
 import { NodeWatchService, INodeWatchServiceOptions } from './watch-service'
 
-const { promises, existsSync } = fs
+const { promises, existsSync, exists } = fs
 
 const caseSensitive = !existsSync(__filename.toUpperCase())
 
@@ -33,7 +33,7 @@ export function createBaseNodeFs(options?: ICreateNodeFsOptions): IBaseFileSyste
         caseSensitive,
         ...fs,
         ...promises,
-        exists: promisify(fs.exists)
+        exists: promisify(exists)
     }
 }
 

--- a/packages/node/src/node-fs.ts
+++ b/packages/node/src/node-fs.ts
@@ -1,6 +1,7 @@
 import path from 'path'
-import { chdir, cwd } from 'process'
 import fs from 'fs'
+import { promisify } from 'util'
+import { chdir, cwd } from 'process'
 
 import { createAsyncFileSystem, createSyncFileSystem } from '@file-services/utils'
 import { IBaseFileSystem, IFileSystem } from '@file-services/types'
@@ -31,7 +32,8 @@ export function createBaseNodeFs(options?: ICreateNodeFsOptions): IBaseFileSyste
         cwd,
         caseSensitive,
         ...fs,
-        ...promises
+        ...promises,
+        exists: promisify(fs.exists)
     }
 }
 

--- a/packages/node/src/tsconfig.json
+++ b/packages/node/src/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json"
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": [
+      "node"
+    ]
+  }
 }

--- a/packages/node/src/watch-service.ts
+++ b/packages/node/src/watch-service.ts
@@ -1,7 +1,9 @@
 import { join } from 'path'
-import { stat, watch, FSWatcher } from 'proper-fs'
+import { promises, watch, FSWatcher } from 'fs'
 import { IWatchService, WatchEventListener, IWatchEvent, IFileSystemStats } from '@file-services/types'
 import { SetMultiMap } from '@file-services/utils'
+
+const { stat } = promises
 
 export interface INodeWatchServiceOptions {
     /**

--- a/packages/node/test/watch-service.spec.ts
+++ b/packages/node/test/watch-service.spec.ts
@@ -1,5 +1,6 @@
 import { join } from 'path'
-import { writeFile, stat, mkdir, rmdir } from 'proper-fs'
+import { promises } from 'fs'
+const { writeFile, stat, mkdir, rmdir } = promises
 import { createTempDirectory, ITempDirectory } from 'create-temp-directory'
 import { IWatchService } from '@file-services/types'
 import { sleep } from 'promise-assist'

--- a/packages/test-kit/src/async-base-fs-contract.ts
+++ b/packages/test-kit/src/async-base-fs-contract.ts
@@ -19,134 +19,153 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         describe('writing files', async () => {
             it('can write a new file into an existing directory', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { stat, readFile, writeFile }
+                    }
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
+                await writeFile(filePath, SAMPLE_CONTENT)
 
-                expect((await fs.promises.stat(filePath)).isFile()).to.equal(true)
-                expect(await fs.promises.readFile(filePath, 'utf8')).to.eql(SAMPLE_CONTENT)
+                expect((await stat(filePath)).isFile()).to.equal(true)
+                expect(await readFile(filePath, 'utf8')).to.eql(SAMPLE_CONTENT)
             })
 
             it('can overwrite an existing file', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { stat, readFile, writeFile }
+                    }
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
-                await fs.promises.writeFile(filePath, DIFFERENT_CONTENT)
+                await writeFile(filePath, SAMPLE_CONTENT)
+                await writeFile(filePath, DIFFERENT_CONTENT)
 
-                expect((await fs.promises.stat(filePath)).isFile()).to.equal(true)
-                expect(await fs.promises.readFile(filePath, 'utf8')).to.eql(DIFFERENT_CONTENT)
+                expect((await stat(filePath)).isFile()).to.equal(true)
+                expect(await readFile(filePath, 'utf8')).to.eql(DIFFERENT_CONTENT)
             })
 
             it('fails if writing a file to a non-existing directory', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { writeFile }
+                    }
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'missing-dir', 'file')
 
-                await expect(fs.promises.writeFile(filePath, SAMPLE_CONTENT)).to.be.rejectedWith('ENOENT')
+                await expect(writeFile(filePath, SAMPLE_CONTENT)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if writing a file to a path already pointing to a directory', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { writeFile, mkdir }
+                    }
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.promises.mkdir(directoryPath)
+                await mkdir(directoryPath)
 
-                await expect(fs.promises.writeFile(directoryPath, SAMPLE_CONTENT)).to.be.rejectedWith('EISDIR')
+                await expect(writeFile(directoryPath, SAMPLE_CONTENT)).to.be.rejectedWith('EISDIR')
             })
         })
 
         describe('reading files', async () => {
             it('can read the contents of a file', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { readFile, writeFile }
+                    }
                 } = testInput
                 const firstFilePath = path.join(tempDirectoryPath, 'first-file')
                 const secondFilePath = path.join(tempDirectoryPath, 'second-file')
 
-                await fs.promises.writeFile(firstFilePath, SAMPLE_CONTENT)
-                await fs.promises.writeFile(secondFilePath, DIFFERENT_CONTENT)
+                await writeFile(firstFilePath, SAMPLE_CONTENT)
+                await writeFile(secondFilePath, DIFFERENT_CONTENT)
 
-                expect(await fs.promises.readFile(firstFilePath, 'utf8'), 'contents of first-file').to.eql(
-                    SAMPLE_CONTENT
-                )
-                expect(await fs.promises.readFile(secondFilePath, 'utf8'), 'contents of second-file').to.eql(
-                    DIFFERENT_CONTENT
-                )
+                expect(await readFile(firstFilePath, 'utf8'), 'contents of first-file').to.eql(SAMPLE_CONTENT)
+                expect(await readFile(secondFilePath, 'utf8'), 'contents of second-file').to.eql(DIFFERENT_CONTENT)
             })
 
             it('fails if reading a non-existing file', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { readFile }
+                    }
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'missing-file')
 
-                await expect(fs.promises.readFile(filePath, 'utf8')).to.be.rejectedWith('ENOENT')
+                await expect(readFile(filePath, 'utf8')).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if reading a directory as a file', async () => {
-                const { fs, tempDirectoryPath } = testInput
+                const {
+                    fs: {
+                        promises: { readFile }
+                    },
+                    tempDirectoryPath
+                } = testInput
 
-                await expect(fs.promises.readFile(tempDirectoryPath, 'utf8')).to.be.rejectedWith('EISDIR')
+                await expect(readFile(tempDirectoryPath, 'utf8')).to.be.rejectedWith('EISDIR')
             })
         })
 
         describe('removing files', async () => {
             it('can remove files', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { stat, unlink, writeFile }
+                    }
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
-                await fs.promises.unlink(filePath)
+                await writeFile(filePath, SAMPLE_CONTENT)
+                await unlink(filePath)
 
-                await expect(fs.promises.stat(filePath)).to.be.rejectedWith('ENOENT')
+                await expect(stat(filePath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if trying to remove a non-existing file', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { unlink }
+                    }
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'missing-file')
 
-                await expect(fs.promises.unlink(filePath)).to.be.rejectedWith('ENOENT')
+                await expect(unlink(filePath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if trying to remove a directory as a file', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { mkdir, unlink }
+                    }
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.promises.mkdir(directoryPath)
+                await mkdir(directoryPath)
 
-                await expect(fs.promises.unlink(directoryPath)).to.be.rejectedWith() // linux throws `EISDIR`, mac throws `EPERM`
+                await expect(unlink(directoryPath)).to.be.rejectedWith() // linux throws `EISDIR`, mac throws `EPERM`
             })
         })
 
@@ -158,48 +177,63 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
             beforeEach('create temp fixture file and intialize validator', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path, watchService }
+                    fs: {
+                        path,
+                        promises: { writeFile },
+                        watchService
+                    }
                 } = testInput
                 validator = new WatchEventsValidator(watchService)
 
                 testFilePath = path.join(tempDirectoryPath, 'test-file')
 
-                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
+                await writeFile(testFilePath, SAMPLE_CONTENT)
                 await watchService.watchPath(testFilePath)
             })
 
             it('emits watch event when a watched file changes', async () => {
-                const { fs } = testInput
+                const {
+                    fs: {
+                        promises: { writeFile, stat }
+                    }
+                } = testInput
 
-                await fs.promises.writeFile(testFilePath, DIFFERENT_CONTENT)
+                await writeFile(testFilePath, DIFFERENT_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
 
             it('emits watch event when a watched file is removed', async () => {
-                const { fs } = testInput
+                const {
+                    fs: {
+                        promises: { unlink }
+                    }
+                } = testInput
 
-                await fs.promises.unlink(testFilePath)
+                await unlink(testFilePath)
 
                 await validator.validateEvents([{ path: testFilePath, stats: null }])
                 await validator.noMoreEvents()
             })
 
             it('keeps watching if file is deleted and recreated immediately', async () => {
-                const { fs } = testInput
+                const {
+                    fs: {
+                        promises: { unlink, writeFile, stat }
+                    }
+                } = testInput
 
-                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
-                await fs.promises.unlink(testFilePath)
-                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
+                await writeFile(testFilePath, SAMPLE_CONTENT)
+                await unlink(testFilePath)
+                await writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await stat(testFilePath) }])
 
-                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
+                await writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
         })
@@ -207,71 +241,81 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         describe('creating directories', async () => {
             it('can create an empty directory inside an existing one', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { mkdir, stat, readdir }
+                    }
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'new-dir')
 
-                await fs.promises.mkdir(directoryPath)
+                await mkdir(directoryPath)
 
-                expect((await fs.promises.stat(directoryPath)).isDirectory()).to.equal(true)
-                expect(await fs.promises.readdir(directoryPath)).to.eql([])
+                expect((await stat(directoryPath)).isDirectory()).to.equal(true)
+                expect(await readdir(directoryPath)).to.eql([])
             })
 
             it('fails if creating in a path pointing to an existing directory', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { mkdir }
+                    }
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.promises.mkdir(directoryPath)
+                await mkdir(directoryPath)
 
-                await expect(fs.promises.mkdir(directoryPath)).to.be.rejectedWith('EEXIST')
+                await expect(mkdir(directoryPath)).to.be.rejectedWith('EEXIST')
             })
 
             it('fails if creating in a path pointing to an existing file', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { mkdir, writeFile }
+                    }
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
+                await writeFile(filePath, SAMPLE_CONTENT)
 
-                await expect(fs.promises.mkdir(filePath)).to.be.rejectedWith('EEXIST')
+                await expect(mkdir(filePath)).to.be.rejectedWith('EEXIST')
             })
 
             it('fails if creating a directory inside a non-existing directory', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { mkdir }
+                    }
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'outer', 'inner')
 
-                await expect(fs.promises.mkdir(directoryPath)).to.be.rejectedWith('ENOENT')
+                await expect(mkdir(directoryPath)).to.be.rejectedWith('ENOENT')
             })
         })
 
         describe('listing directories', async () => {
             it('can list an existing directory', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { mkdir, writeFile, readdir }
+                    }
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.promises.mkdir(directoryPath)
-                await fs.promises.writeFile(path.join(directoryPath, 'file1'), SAMPLE_CONTENT)
-                await fs.promises.writeFile(path.join(directoryPath, 'camelCasedName'), SAMPLE_CONTENT)
+                await mkdir(directoryPath)
+                await writeFile(path.join(directoryPath, 'file1'), SAMPLE_CONTENT)
+                await writeFile(path.join(directoryPath, 'camelCasedName'), SAMPLE_CONTENT)
 
-                expect(await fs.promises.readdir(tempDirectoryPath)).to.eql(['dir'])
-                const directoryContents = await fs.promises.readdir(directoryPath)
+                expect(await readdir(tempDirectoryPath)).to.eql(['dir'])
+                const directoryContents = await readdir(directoryPath)
                 expect(directoryContents).to.have.lengthOf(2)
                 expect(directoryContents).to.contain('file1')
                 expect(directoryContents).to.contain('camelCasedName')
@@ -279,81 +323,92 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
             it('fails if listing a non-existing directory', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { readdir }
+                    }
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'missing-dir')
 
-                await expect(fs.promises.readdir(directoryPath)).to.be.rejectedWith('ENOENT')
+                await expect(readdir(directoryPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if listing a path pointing to a file', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { writeFile, readdir }
+                    }
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
+                await writeFile(filePath, SAMPLE_CONTENT)
 
-                await expect(fs.promises.readdir(filePath)).to.be.rejectedWith('ENOTDIR')
+                await expect(readdir(filePath)).to.be.rejectedWith('ENOTDIR')
             })
         })
 
         describe('removing directories', async () => {
             it('can remove an existing directory', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { mkdir, rmdir, stat }
+                    }
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.promises.mkdir(directoryPath)
-                await fs.promises.rmdir(directoryPath)
+                await mkdir(directoryPath)
+                await rmdir(directoryPath)
 
-                await expect(fs.promises.stat(directoryPath)).to.be.rejectedWith('ENOENT')
+                await expect(stat(directoryPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if removing a non-empty directory', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { mkdir, writeFile, rmdir }
+                    }
                 } = testInput
-                const { join } = fs.path
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.promises.mkdir(directoryPath)
-                await fs.promises.writeFile(join(directoryPath, 'file'), SAMPLE_CONTENT)
+                await mkdir(directoryPath)
+                await writeFile(path.join(directoryPath, 'file'), SAMPLE_CONTENT)
 
-                await expect(fs.promises.rmdir(directoryPath)).to.be.rejectedWith('ENOTEMPTY')
+                await expect(rmdir(directoryPath)).to.be.rejectedWith('ENOTEMPTY')
             })
 
             it('fails if removing a non-existing directory', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { rmdir }
+                    }
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'missing-dir')
 
-                await expect(fs.promises.rmdir(directoryPath)).to.be.rejectedWith('ENOENT')
+                await expect(rmdir(directoryPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if removing a path pointing to a file', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { rmdir, writeFile }
+                    }
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
+                await writeFile(filePath, SAMPLE_CONTENT)
 
-                await expect(fs.promises.rmdir(filePath)).to.be.rejectedWith()
+                await expect(rmdir(filePath)).to.be.rejectedWith()
             })
         })
 
@@ -365,58 +420,70 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
             beforeEach('create temp fixture directory and intialize validator', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path, watchService }
+                    fs: {
+                        promises: { mkdir },
+                        path,
+                        watchService
+                    }
                 } = testInput
                 validator = new WatchEventsValidator(watchService)
 
                 testDirectoryPath = path.join(tempDirectoryPath, 'test-directory')
-                await fs.promises.mkdir(testDirectoryPath)
+                await mkdir(testDirectoryPath)
             })
 
             it('fires a watch event when a file is added inside a watched directory', async () => {
                 const {
-                    fs,
-                    fs: { path, watchService }
+                    fs: {
+                        promises: { writeFile, stat },
+                        path,
+                        watchService
+                    }
                 } = testInput
 
                 await watchService.watchPath(testDirectoryPath)
 
                 const testFilePath = path.join(testDirectoryPath, 'test-file')
-                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
+                await writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
 
             it('fires a watch event when a file is changed inside a watched directory', async () => {
                 const {
-                    fs,
-                    fs: { path, watchService }
+                    fs: {
+                        promises: { writeFile, stat },
+                        path,
+                        watchService
+                    }
                 } = testInput
 
                 const testFilePath = path.join(testDirectoryPath, 'test-file')
-                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
+                await writeFile(testFilePath, SAMPLE_CONTENT)
                 await watchService.watchPath(testDirectoryPath)
 
-                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
+                await writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
 
             it('fires a watch event when a file is removed inside a watched directory', async () => {
                 const {
-                    fs,
-                    fs: { path, watchService }
+                    fs: {
+                        promises: { writeFile, unlink },
+                        path,
+                        watchService
+                    }
                 } = testInput
 
                 const testFilePath = path.join(testDirectoryPath, 'test-file')
-                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
+                await writeFile(testFilePath, SAMPLE_CONTENT)
                 await watchService.watchPath(testDirectoryPath)
 
-                await fs.promises.unlink(testFilePath)
+                await unlink(testFilePath)
 
                 await validator.validateEvents([{ path: testFilePath, stats: null }])
                 await validator.noMoreEvents()
@@ -432,45 +499,52 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
             beforeEach('create temp fixture directory and intialize watch service', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path, watchService }
+                    fs: {
+                        promises: { writeFile, mkdir },
+                        path,
+                        watchService
+                    }
                 } = testInput
                 validator = new WatchEventsValidator(watchService)
 
                 testDirectoryPath = path.join(tempDirectoryPath, 'test-directory')
-                await fs.promises.mkdir(testDirectoryPath)
+                await mkdir(testDirectoryPath)
                 testFilePath = path.join(testDirectoryPath, 'test-file')
-                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
+                await writeFile(testFilePath, SAMPLE_CONTENT)
             })
 
             it('allows watching a file and its containing directory', async () => {
                 const {
-                    fs,
-                    fs: { watchService }
+                    fs: {
+                        promises: { writeFile, stat },
+                        watchService
+                    }
                 } = testInput
 
                 await watchService.watchPath(testFilePath)
                 await watchService.watchPath(testDirectoryPath)
 
-                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
+                await writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
 
             it('allows watching in any order', async () => {
                 const {
-                    fs,
-                    fs: { watchService }
+                    fs: {
+                        promises: { writeFile, stat },
+                        watchService
+                    }
                 } = testInput
 
                 await watchService.watchPath(testDirectoryPath)
                 await watchService.watchPath(testFilePath)
 
-                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
+                await writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
         })
@@ -478,141 +552,172 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         describe('renaming directories and files', () => {
             it('moves a file', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { writeFile, stat, mkdir, rename, readFile }
+                    }
                 } = testInput
                 const sourcePath = path.join(tempDirectoryPath, 'file')
                 const destinationPath = path.join(tempDirectoryPath, 'dir', 'subdir', 'movedFile')
 
-                await fs.promises.writeFile(sourcePath, SAMPLE_CONTENT)
-                await fs.promises.mkdir(path.join(tempDirectoryPath, 'dir'))
-                await fs.promises.mkdir(path.join(tempDirectoryPath, 'dir', 'subdir'))
+                await writeFile(sourcePath, SAMPLE_CONTENT)
+                await mkdir(path.join(tempDirectoryPath, 'dir'))
+                await mkdir(path.join(tempDirectoryPath, 'dir', 'subdir'))
 
-                const sourceStats = await fs.promises.stat(sourcePath)
+                const sourceStats = await stat(sourcePath)
 
-                await fs.promises.rename(sourcePath, destinationPath)
+                await rename(sourcePath, destinationPath)
 
-                const destStats = await fs.promises.stat(destinationPath)
+                const destStats = await stat(destinationPath)
                 expect(destStats.isFile()).to.equal(true)
                 expect(destStats.mtime).not.to.equal(sourceStats.mtime)
-                expect(await fs.promises.readFile(destinationPath, 'utf8')).to.eql(SAMPLE_CONTENT)
-                await expect(fs.promises.stat(sourcePath)).to.be.rejectedWith('ENOENT')
+                expect(await readFile(destinationPath, 'utf8')).to.eql(SAMPLE_CONTENT)
+                await expect(stat(sourcePath)).to.be.rejectedWith('ENOENT')
             })
 
             it(`throws if source path doesn't exist`, async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { rename }
+                    }
                 } = testInput
                 const sourcePath = path.join(tempDirectoryPath, 'file')
                 const destPath = path.join(tempDirectoryPath, 'file2')
 
-                await expect(fs.promises.rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
+                await expect(rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
             })
 
             it(`throws if the containing directory of the source path doesn't exist`, async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { rename }
+                    }
                 } = testInput
                 const sourcePath = path.join(tempDirectoryPath, 'unicorn', 'file')
                 const destPath = path.join(tempDirectoryPath, 'file2')
 
-                await expect(fs.promises.rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
+                await expect(rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
             })
 
             it(`throws if destination containing path doesn't exist`, async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { rename, writeFile }
+                    }
                 } = testInput
                 const sourcePath = path.join(tempDirectoryPath, 'file')
                 const destPath = path.join(tempDirectoryPath, 'dir', 'file2')
 
-                await fs.promises.writeFile(sourcePath, SAMPLE_CONTENT)
+                await writeFile(sourcePath, SAMPLE_CONTENT)
 
-                await expect(fs.promises.rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
+                await expect(rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('updates the parent directory of a renamed entry', async () => {
-                const { fs, tempDirectoryPath } = testInput
-                const { join } = fs.path
-                const sourcePath = join(tempDirectoryPath, 'sourceDir')
-                const destPath = join(tempDirectoryPath, 'destDir')
+                const {
+                    tempDirectoryPath,
+                    fs: {
+                        path,
+                        promises: { rename, mkdir, readdir, writeFile }
+                    }
+                } = testInput
+                const sourcePath = path.join(tempDirectoryPath, 'sourceDir')
+                const destPath = path.join(tempDirectoryPath, 'destDir')
 
-                await fs.promises.mkdir(sourcePath)
-                await fs.promises.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
+                await mkdir(sourcePath)
+                await writeFile(path.join(sourcePath, 'file'), SAMPLE_CONTENT)
 
-                await fs.promises.rename(sourcePath, destPath)
+                await rename(sourcePath, destPath)
 
-                expect(await fs.promises.readdir(tempDirectoryPath)).to.include('destDir')
+                expect(await readdir(tempDirectoryPath)).to.include('destDir')
             })
 
             describe('renaming directories', () => {
                 it('moves a directory', async () => {
-                    const { fs, tempDirectoryPath } = testInput
-                    const { join } = fs.path
-                    const sourcePath = join(tempDirectoryPath, 'dir')
-                    const destinationPath = join(tempDirectoryPath, 'anotherDir', 'subdir', 'movedDir')
-                    await fs.promises.mkdir(join(tempDirectoryPath, 'dir'))
-                    await fs.promises.mkdir(join(tempDirectoryPath, 'anotherDir'))
-                    await fs.promises.mkdir(join(tempDirectoryPath, 'anotherDir', 'subdir'))
-                    await fs.promises.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
+                    const {
+                        tempDirectoryPath,
+                        fs: {
+                            path,
+                            promises: { rename, mkdir, writeFile, stat, readFile }
+                        }
+                    } = testInput
+                    const sourcePath = path.join(tempDirectoryPath, 'dir')
+                    const destinationPath = path.join(tempDirectoryPath, 'anotherDir', 'subdir', 'movedDir')
+                    await mkdir(path.join(tempDirectoryPath, 'dir'))
+                    await mkdir(path.join(tempDirectoryPath, 'anotherDir'))
+                    await mkdir(path.join(tempDirectoryPath, 'anotherDir', 'subdir'))
+                    await writeFile(path.join(sourcePath, 'file'), SAMPLE_CONTENT)
 
-                    await fs.promises.rename(sourcePath, destinationPath)
+                    await rename(sourcePath, destinationPath)
 
-                    expect((await fs.promises.stat(destinationPath)).isDirectory()).to.equal(true)
-                    expect(await fs.promises.readFile(join(destinationPath, 'file'), 'utf8')).to.eql(SAMPLE_CONTENT)
-                    await expect(fs.promises.stat(sourcePath)).to.be.rejectedWith('ENOENT')
+                    expect((await stat(destinationPath)).isDirectory()).to.equal(true)
+                    expect(await readFile(path.join(destinationPath, 'file'), 'utf8')).to.eql(SAMPLE_CONTENT)
+                    await expect(stat(sourcePath)).to.be.rejectedWith('ENOENT')
                 })
 
                 it(`allows copying a directory over a non-existing directory`, async () => {
-                    const { fs, tempDirectoryPath } = testInput
-                    const { join } = fs.path
-                    const sourcePath = join(tempDirectoryPath, 'sourceDir')
+                    const {
+                        tempDirectoryPath,
+                        fs: {
+                            path,
+                            promises: { rename, mkdir, writeFile }
+                        }
+                    } = testInput
+                    const sourcePath = path.join(tempDirectoryPath, 'sourceDir')
 
-                    await fs.promises.mkdir(sourcePath)
-                    await fs.promises.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
+                    await mkdir(sourcePath)
+                    await writeFile(path.join(sourcePath, 'file'), SAMPLE_CONTENT)
 
-                    await expect(
-                        fs.promises.rename(sourcePath, join(tempDirectoryPath, 'destDir'))
-                    ).to.not.be.rejectedWith('EEXIST')
+                    await expect(rename(sourcePath, path.join(tempDirectoryPath, 'destDir'))).to.not.be.rejectedWith(
+                        'EEXIST'
+                    )
                 })
 
                 it(`allows copying copying a directory over an empty directory`, async () => {
-                    const { fs, tempDirectoryPath } = testInput
-                    const { join } = fs.path
-                    const sourcePath = join(tempDirectoryPath, 'sourceDir')
-                    const destPath = join(tempDirectoryPath, 'destDir')
+                    const {
+                        tempDirectoryPath,
+                        fs: {
+                            path,
+                            promises: { rename, mkdir, writeFile }
+                        }
+                    } = testInput
+                    const sourcePath = path.join(tempDirectoryPath, 'sourceDir')
+                    const destPath = path.join(tempDirectoryPath, 'destDir')
 
-                    await fs.promises.mkdir(sourcePath)
-                    await fs.promises.mkdir(destPath)
-                    await fs.promises.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
+                    await mkdir(sourcePath)
+                    await mkdir(destPath)
+                    await writeFile(path.join(sourcePath, 'file'), SAMPLE_CONTENT)
 
-                    await expect(fs.promises.rename(sourcePath, destPath)).to.not.be.rejectedWith('EEXIST')
+                    await expect(rename(sourcePath, destPath)).to.not.be.rejectedWith('EEXIST')
                 })
             })
         })
 
         it('correctly exposes whether it is case sensitive', async () => {
             const {
-                fs,
                 tempDirectoryPath,
-                fs: { path }
+                fs: {
+                    path,
+                    caseSensitive,
+                    promises: { writeFile, stat }
+                }
             } = testInput
             const filePath = path.join(tempDirectoryPath, 'file')
             const upperCaseFilePath = filePath.toUpperCase()
 
-            await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
+            await writeFile(filePath, SAMPLE_CONTENT)
 
-            if (fs.caseSensitive) {
-                await expect(fs.promises.stat(upperCaseFilePath)).to.be.rejectedWith('ENOENT')
+            if (caseSensitive) {
+                await expect(stat(upperCaseFilePath)).to.be.rejectedWith('ENOENT')
             } else {
-                await expect((await fs.promises.stat(upperCaseFilePath)).isFile()).to.equal(true)
+                await expect((await stat(upperCaseFilePath)).isFile()).to.equal(true)
             }
         })
 
@@ -623,74 +728,87 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
             beforeEach(async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { writeFile, mkdir }
+                    }
                 } = testInput
                 targetDirectoryPath = path.join(tempDirectoryPath, 'dir')
-                await fs.promises.mkdir(targetDirectoryPath)
+
+                await mkdir(targetDirectoryPath)
                 sourceFilePath = path.join(tempDirectoryPath, SOURCE_FILE_NAME)
-                await fs.promises.writeFile(sourceFilePath, SAMPLE_CONTENT)
+                await writeFile(sourceFilePath, SAMPLE_CONTENT)
             })
 
             it('can copy file', async () => {
                 const {
-                    fs,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { copyFile, readFile }
+                    }
                 } = testInput
                 const targetPath = path.join(targetDirectoryPath, SOURCE_FILE_NAME)
 
-                await fs.promises.copyFile(sourceFilePath, targetPath)
+                await copyFile(sourceFilePath, targetPath)
 
-                expect(await fs.promises.readFile(targetPath, 'utf8')).to.be.eql(SAMPLE_CONTENT)
+                expect(await readFile(targetPath, 'utf8')).to.be.eql(SAMPLE_CONTENT)
             })
 
             it('fails if source does not exist', async () => {
                 const {
-                    fs,
                     tempDirectoryPath,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { copyFile }
+                    }
                 } = testInput
                 const sourcePath = path.join(tempDirectoryPath, 'nonExistingFileName.txt')
                 const targetPath = path.join(targetDirectoryPath, SOURCE_FILE_NAME)
 
-                await expect(fs.promises.copyFile(sourcePath, targetPath)).to.be.rejectedWith('ENOENT')
+                await expect(copyFile(sourcePath, targetPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if target containing directory does not exist', async () => {
                 const {
-                    fs,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { copyFile }
+                    }
                 } = testInput
                 const targetPath = path.join(targetDirectoryPath, 'nonExistingDirectory', SOURCE_FILE_NAME)
 
-                await expect(fs.promises.copyFile(sourceFilePath, targetPath)).to.be.rejectedWith('ENOENT')
+                await expect(copyFile(sourceFilePath, targetPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('overwrites destination file by default', async () => {
                 const {
-                    fs,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { copyFile, readFile, writeFile }
+                    }
                 } = testInput
                 const targetPath = path.join(targetDirectoryPath, SOURCE_FILE_NAME)
 
-                await fs.promises.writeFile(targetPath, 'content to be overwritten')
-                await fs.promises.copyFile(sourceFilePath, targetPath)
+                await writeFile(targetPath, 'content to be overwritten')
+                await copyFile(sourceFilePath, targetPath)
 
-                expect(await fs.promises.readFile(targetPath, 'utf8')).to.be.eql(SAMPLE_CONTENT)
+                expect(await readFile(targetPath, 'utf8')).to.be.eql(SAMPLE_CONTENT)
             })
 
             it('fails if destination exists and flag COPYFILE_EXCL passed', async () => {
                 const {
-                    fs,
-                    fs: { path }
+                    fs: {
+                        path,
+                        promises: { copyFile, writeFile }
+                    }
                 } = testInput
                 const targetPath = path.join(targetDirectoryPath, SOURCE_FILE_NAME)
 
-                await fs.promises.writeFile(targetPath, 'content to be overwritten')
+                await writeFile(targetPath, 'content to be overwritten')
 
                 await expect(
-                    fs.promises.copyFile(sourceFilePath, targetPath, FileSystemConstants.COPYFILE_EXCL)
+                    copyFile(sourceFilePath, targetPath, FileSystemConstants.COPYFILE_EXCL)
                 ).to.be.rejectedWith('EEXIST')
             })
         })

--- a/packages/test-kit/src/async-base-fs-contract.ts
+++ b/packages/test-kit/src/async-base-fs-contract.ts
@@ -25,10 +25,10 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.writeFile(filePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
 
-                expect((await fs.stat(filePath)).isFile()).to.equal(true)
-                expect(await fs.readFile(filePath, 'utf8')).to.eql(SAMPLE_CONTENT)
+                expect((await fs.promises.stat(filePath)).isFile()).to.equal(true)
+                expect(await fs.promises.readFile(filePath, 'utf8')).to.eql(SAMPLE_CONTENT)
             })
 
             it('can overwrite an existing file', async () => {
@@ -39,11 +39,11 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.writeFile(filePath, SAMPLE_CONTENT)
-                await fs.writeFile(filePath, DIFFERENT_CONTENT)
+                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(filePath, DIFFERENT_CONTENT)
 
-                expect((await fs.stat(filePath)).isFile()).to.equal(true)
-                expect(await fs.readFile(filePath, 'utf8')).to.eql(DIFFERENT_CONTENT)
+                expect((await fs.promises.stat(filePath)).isFile()).to.equal(true)
+                expect(await fs.promises.readFile(filePath, 'utf8')).to.eql(DIFFERENT_CONTENT)
             })
 
             it('fails if writing a file to a non-existing directory', async () => {
@@ -54,7 +54,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'missing-dir', 'file')
 
-                await expect(fs.writeFile(filePath, SAMPLE_CONTENT)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.writeFile(filePath, SAMPLE_CONTENT)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if writing a file to a path already pointing to a directory', async () => {
@@ -65,9 +65,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.mkdir(directoryPath)
+                await fs.promises.mkdir(directoryPath)
 
-                await expect(fs.writeFile(directoryPath, SAMPLE_CONTENT)).to.be.rejectedWith('EISDIR')
+                await expect(fs.promises.writeFile(directoryPath, SAMPLE_CONTENT)).to.be.rejectedWith('EISDIR')
             })
         })
 
@@ -81,11 +81,15 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 const firstFilePath = path.join(tempDirectoryPath, 'first-file')
                 const secondFilePath = path.join(tempDirectoryPath, 'second-file')
 
-                await fs.writeFile(firstFilePath, SAMPLE_CONTENT)
-                await fs.writeFile(secondFilePath, DIFFERENT_CONTENT)
+                await fs.promises.writeFile(firstFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(secondFilePath, DIFFERENT_CONTENT)
 
-                expect(await fs.readFile(firstFilePath, 'utf8'), 'contents of first-file').to.eql(SAMPLE_CONTENT)
-                expect(await fs.readFile(secondFilePath, 'utf8'), 'contents of second-file').to.eql(DIFFERENT_CONTENT)
+                expect(await fs.promises.readFile(firstFilePath, 'utf8'), 'contents of first-file').to.eql(
+                    SAMPLE_CONTENT
+                )
+                expect(await fs.promises.readFile(secondFilePath, 'utf8'), 'contents of second-file').to.eql(
+                    DIFFERENT_CONTENT
+                )
             })
 
             it('fails if reading a non-existing file', async () => {
@@ -96,13 +100,13 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'missing-file')
 
-                await expect(fs.readFile(filePath, 'utf8')).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.readFile(filePath, 'utf8')).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if reading a directory as a file', async () => {
                 const { fs, tempDirectoryPath } = testInput
 
-                await expect(fs.readFile(tempDirectoryPath, 'utf8')).to.be.rejectedWith('EISDIR')
+                await expect(fs.promises.readFile(tempDirectoryPath, 'utf8')).to.be.rejectedWith('EISDIR')
             })
         })
 
@@ -115,10 +119,10 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.writeFile(filePath, SAMPLE_CONTENT)
-                await fs.unlink(filePath)
+                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
+                await fs.promises.unlink(filePath)
 
-                await expect(fs.stat(filePath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.stat(filePath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if trying to remove a non-existing file', async () => {
@@ -129,7 +133,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'missing-file')
 
-                await expect(fs.unlink(filePath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.unlink(filePath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if trying to remove a directory as a file', async () => {
@@ -140,9 +144,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.mkdir(directoryPath)
+                await fs.promises.mkdir(directoryPath)
 
-                await expect(fs.unlink(directoryPath)).to.be.rejectedWith() // linux throws `EISDIR`, mac throws `EPERM`
+                await expect(fs.promises.unlink(directoryPath)).to.be.rejectedWith() // linux throws `EISDIR`, mac throws `EPERM`
             })
         })
 
@@ -162,23 +166,23 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
                 testFilePath = path.join(tempDirectoryPath, 'test-file')
 
-                await fs.writeFile(testFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
                 await watchService.watchPath(testFilePath)
             })
 
             it('emits watch event when a watched file changes', async () => {
                 const { fs } = testInput
 
-                await fs.writeFile(testFilePath, DIFFERENT_CONTENT)
+                await fs.promises.writeFile(testFilePath, DIFFERENT_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
 
             it('emits watch event when a watched file is removed', async () => {
                 const { fs } = testInput
 
-                await fs.unlink(testFilePath)
+                await fs.promises.unlink(testFilePath)
 
                 await validator.validateEvents([{ path: testFilePath, stats: null }])
                 await validator.noMoreEvents()
@@ -187,15 +191,15 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
             it('keeps watching if file is deleted and recreated immediately', async () => {
                 const { fs } = testInput
 
-                await fs.writeFile(testFilePath, SAMPLE_CONTENT)
-                await fs.unlink(testFilePath)
-                await fs.writeFile(testFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
+                await fs.promises.unlink(testFilePath)
+                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
 
-                await fs.writeFile(testFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
         })
@@ -209,10 +213,10 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'new-dir')
 
-                await fs.mkdir(directoryPath)
+                await fs.promises.mkdir(directoryPath)
 
-                expect((await fs.stat(directoryPath)).isDirectory()).to.equal(true)
-                expect(await fs.readdir(directoryPath)).to.eql([])
+                expect((await fs.promises.stat(directoryPath)).isDirectory()).to.equal(true)
+                expect(await fs.promises.readdir(directoryPath)).to.eql([])
             })
 
             it('fails if creating in a path pointing to an existing directory', async () => {
@@ -223,9 +227,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.mkdir(directoryPath)
+                await fs.promises.mkdir(directoryPath)
 
-                await expect(fs.mkdir(directoryPath)).to.be.rejectedWith('EEXIST')
+                await expect(fs.promises.mkdir(directoryPath)).to.be.rejectedWith('EEXIST')
             })
 
             it('fails if creating in a path pointing to an existing file', async () => {
@@ -236,9 +240,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.writeFile(filePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
 
-                await expect(fs.mkdir(filePath)).to.be.rejectedWith('EEXIST')
+                await expect(fs.promises.mkdir(filePath)).to.be.rejectedWith('EEXIST')
             })
 
             it('fails if creating a directory inside a non-existing directory', async () => {
@@ -249,7 +253,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'outer', 'inner')
 
-                await expect(fs.mkdir(directoryPath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.mkdir(directoryPath)).to.be.rejectedWith('ENOENT')
             })
         })
 
@@ -262,12 +266,12 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.mkdir(directoryPath)
-                await fs.writeFile(path.join(directoryPath, 'file1'), SAMPLE_CONTENT)
-                await fs.writeFile(path.join(directoryPath, 'camelCasedName'), SAMPLE_CONTENT)
+                await fs.promises.mkdir(directoryPath)
+                await fs.promises.writeFile(path.join(directoryPath, 'file1'), SAMPLE_CONTENT)
+                await fs.promises.writeFile(path.join(directoryPath, 'camelCasedName'), SAMPLE_CONTENT)
 
-                expect(await fs.readdir(tempDirectoryPath)).to.eql(['dir'])
-                const directoryContents = await fs.readdir(directoryPath)
+                expect(await fs.promises.readdir(tempDirectoryPath)).to.eql(['dir'])
+                const directoryContents = await fs.promises.readdir(directoryPath)
                 expect(directoryContents).to.have.lengthOf(2)
                 expect(directoryContents).to.contain('file1')
                 expect(directoryContents).to.contain('camelCasedName')
@@ -281,7 +285,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'missing-dir')
 
-                await expect(fs.readdir(directoryPath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.readdir(directoryPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if listing a path pointing to a file', async () => {
@@ -292,9 +296,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.writeFile(filePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
 
-                await expect(fs.readdir(filePath)).to.be.rejectedWith('ENOTDIR')
+                await expect(fs.promises.readdir(filePath)).to.be.rejectedWith('ENOTDIR')
             })
         })
 
@@ -307,10 +311,10 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.mkdir(directoryPath)
-                await fs.rmdir(directoryPath)
+                await fs.promises.mkdir(directoryPath)
+                await fs.promises.rmdir(directoryPath)
 
-                await expect(fs.stat(directoryPath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.stat(directoryPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if removing a non-empty directory', async () => {
@@ -322,10 +326,10 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 const { join } = fs.path
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.mkdir(directoryPath)
-                await fs.writeFile(join(directoryPath, 'file'), SAMPLE_CONTENT)
+                await fs.promises.mkdir(directoryPath)
+                await fs.promises.writeFile(join(directoryPath, 'file'), SAMPLE_CONTENT)
 
-                await expect(fs.rmdir(directoryPath)).to.be.rejectedWith('ENOTEMPTY')
+                await expect(fs.promises.rmdir(directoryPath)).to.be.rejectedWith('ENOTEMPTY')
             })
 
             it('fails if removing a non-existing directory', async () => {
@@ -336,7 +340,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'missing-dir')
 
-                await expect(fs.rmdir(directoryPath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.rmdir(directoryPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if removing a path pointing to a file', async () => {
@@ -347,9 +351,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const filePath = path.join(tempDirectoryPath, 'file')
 
-                await fs.writeFile(filePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
 
-                await expect(fs.rmdir(filePath)).to.be.rejectedWith()
+                await expect(fs.promises.rmdir(filePath)).to.be.rejectedWith()
             })
         })
 
@@ -368,7 +372,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 validator = new WatchEventsValidator(watchService)
 
                 testDirectoryPath = path.join(tempDirectoryPath, 'test-directory')
-                await fs.mkdir(testDirectoryPath)
+                await fs.promises.mkdir(testDirectoryPath)
             })
 
             it('fires a watch event when a file is added inside a watched directory', async () => {
@@ -380,9 +384,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 await watchService.watchPath(testDirectoryPath)
 
                 const testFilePath = path.join(testDirectoryPath, 'test-file')
-                await fs.writeFile(testFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
 
@@ -393,12 +397,12 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
 
                 const testFilePath = path.join(testDirectoryPath, 'test-file')
-                await fs.writeFile(testFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
                 await watchService.watchPath(testDirectoryPath)
 
-                await fs.writeFile(testFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
 
@@ -409,10 +413,10 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
 
                 const testFilePath = path.join(testDirectoryPath, 'test-file')
-                await fs.writeFile(testFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
                 await watchService.watchPath(testDirectoryPath)
 
-                await fs.unlink(testFilePath)
+                await fs.promises.unlink(testFilePath)
 
                 await validator.validateEvents([{ path: testFilePath, stats: null }])
                 await validator.noMoreEvents()
@@ -435,9 +439,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 validator = new WatchEventsValidator(watchService)
 
                 testDirectoryPath = path.join(tempDirectoryPath, 'test-directory')
-                await fs.mkdir(testDirectoryPath)
+                await fs.promises.mkdir(testDirectoryPath)
                 testFilePath = path.join(testDirectoryPath, 'test-file')
-                await fs.writeFile(testFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
             })
 
             it('allows watching a file and its containing directory', async () => {
@@ -449,9 +453,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 await watchService.watchPath(testFilePath)
                 await watchService.watchPath(testDirectoryPath)
 
-                await fs.writeFile(testFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
 
@@ -464,9 +468,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 await watchService.watchPath(testDirectoryPath)
                 await watchService.watchPath(testFilePath)
 
-                await fs.writeFile(testFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(testFilePath, SAMPLE_CONTENT)
 
-                await validator.validateEvents([{ path: testFilePath, stats: await fs.stat(testFilePath) }])
+                await validator.validateEvents([{ path: testFilePath, stats: await fs.promises.stat(testFilePath) }])
                 await validator.noMoreEvents()
             })
         })
@@ -481,19 +485,19 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 const sourcePath = path.join(tempDirectoryPath, 'file')
                 const destinationPath = path.join(tempDirectoryPath, 'dir', 'subdir', 'movedFile')
 
-                await fs.writeFile(sourcePath, SAMPLE_CONTENT)
-                await fs.mkdir(path.join(tempDirectoryPath, 'dir'))
-                await fs.mkdir(path.join(tempDirectoryPath, 'dir', 'subdir'))
+                await fs.promises.writeFile(sourcePath, SAMPLE_CONTENT)
+                await fs.promises.mkdir(path.join(tempDirectoryPath, 'dir'))
+                await fs.promises.mkdir(path.join(tempDirectoryPath, 'dir', 'subdir'))
 
-                const sourceStats = await fs.stat(sourcePath)
+                const sourceStats = await fs.promises.stat(sourcePath)
 
-                await fs.rename(sourcePath, destinationPath)
+                await fs.promises.rename(sourcePath, destinationPath)
 
-                const destStats = await fs.stat(destinationPath)
+                const destStats = await fs.promises.stat(destinationPath)
                 expect(destStats.isFile()).to.equal(true)
                 expect(destStats.mtime).not.to.equal(sourceStats.mtime)
-                expect(await fs.readFile(destinationPath, 'utf8')).to.eql(SAMPLE_CONTENT)
-                await expect(fs.stat(sourcePath)).to.be.rejectedWith('ENOENT')
+                expect(await fs.promises.readFile(destinationPath, 'utf8')).to.eql(SAMPLE_CONTENT)
+                await expect(fs.promises.stat(sourcePath)).to.be.rejectedWith('ENOENT')
             })
 
             it(`throws if source path doesn't exist`, async () => {
@@ -505,7 +509,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 const sourcePath = path.join(tempDirectoryPath, 'file')
                 const destPath = path.join(tempDirectoryPath, 'file2')
 
-                await expect(fs.rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
             })
 
             it(`throws if the containing directory of the source path doesn't exist`, async () => {
@@ -517,7 +521,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 const sourcePath = path.join(tempDirectoryPath, 'unicorn', 'file')
                 const destPath = path.join(tempDirectoryPath, 'file2')
 
-                await expect(fs.rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
             })
 
             it(`throws if destination containing path doesn't exist`, async () => {
@@ -529,9 +533,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 const sourcePath = path.join(tempDirectoryPath, 'file')
                 const destPath = path.join(tempDirectoryPath, 'dir', 'file2')
 
-                await fs.writeFile(sourcePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(sourcePath, SAMPLE_CONTENT)
 
-                await expect(fs.rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.rename(sourcePath, destPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('updates the parent directory of a renamed entry', async () => {
@@ -540,12 +544,12 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 const sourcePath = join(tempDirectoryPath, 'sourceDir')
                 const destPath = join(tempDirectoryPath, 'destDir')
 
-                await fs.mkdir(sourcePath)
-                await fs.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
+                await fs.promises.mkdir(sourcePath)
+                await fs.promises.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
 
-                await fs.rename(sourcePath, destPath)
+                await fs.promises.rename(sourcePath, destPath)
 
-                expect(await fs.readdir(tempDirectoryPath)).to.include('destDir')
+                expect(await fs.promises.readdir(tempDirectoryPath)).to.include('destDir')
             })
 
             describe('renaming directories', () => {
@@ -554,16 +558,16 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                     const { join } = fs.path
                     const sourcePath = join(tempDirectoryPath, 'dir')
                     const destinationPath = join(tempDirectoryPath, 'anotherDir', 'subdir', 'movedDir')
-                    await fs.mkdir(join(tempDirectoryPath, 'dir'))
-                    await fs.mkdir(join(tempDirectoryPath, 'anotherDir'))
-                    await fs.mkdir(join(tempDirectoryPath, 'anotherDir', 'subdir'))
-                    await fs.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
+                    await fs.promises.mkdir(join(tempDirectoryPath, 'dir'))
+                    await fs.promises.mkdir(join(tempDirectoryPath, 'anotherDir'))
+                    await fs.promises.mkdir(join(tempDirectoryPath, 'anotherDir', 'subdir'))
+                    await fs.promises.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
 
-                    await fs.rename(sourcePath, destinationPath)
+                    await fs.promises.rename(sourcePath, destinationPath)
 
-                    expect((await fs.stat(destinationPath)).isDirectory()).to.equal(true)
-                    expect(await fs.readFile(join(destinationPath, 'file'), 'utf8')).to.eql(SAMPLE_CONTENT)
-                    await expect(fs.stat(sourcePath)).to.be.rejectedWith('ENOENT')
+                    expect((await fs.promises.stat(destinationPath)).isDirectory()).to.equal(true)
+                    expect(await fs.promises.readFile(join(destinationPath, 'file'), 'utf8')).to.eql(SAMPLE_CONTENT)
+                    await expect(fs.promises.stat(sourcePath)).to.be.rejectedWith('ENOENT')
                 })
 
                 it(`allows copying a directory over a non-existing directory`, async () => {
@@ -571,12 +575,12 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                     const { join } = fs.path
                     const sourcePath = join(tempDirectoryPath, 'sourceDir')
 
-                    await fs.mkdir(sourcePath)
-                    await fs.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
+                    await fs.promises.mkdir(sourcePath)
+                    await fs.promises.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
 
-                    await expect(fs.rename(sourcePath, join(tempDirectoryPath, 'destDir'))).to.not.be.rejectedWith(
-                        'EEXIST'
-                    )
+                    await expect(
+                        fs.promises.rename(sourcePath, join(tempDirectoryPath, 'destDir'))
+                    ).to.not.be.rejectedWith('EEXIST')
                 })
 
                 it(`allows copying copying a directory over an empty directory`, async () => {
@@ -585,11 +589,11 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                     const sourcePath = join(tempDirectoryPath, 'sourceDir')
                     const destPath = join(tempDirectoryPath, 'destDir')
 
-                    await fs.mkdir(sourcePath)
-                    await fs.mkdir(destPath)
-                    await fs.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
+                    await fs.promises.mkdir(sourcePath)
+                    await fs.promises.mkdir(destPath)
+                    await fs.promises.writeFile(join(sourcePath, 'file'), SAMPLE_CONTENT)
 
-                    await expect(fs.rename(sourcePath, destPath)).to.not.be.rejectedWith('EEXIST')
+                    await expect(fs.promises.rename(sourcePath, destPath)).to.not.be.rejectedWith('EEXIST')
                 })
             })
         })
@@ -603,12 +607,12 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
             const filePath = path.join(tempDirectoryPath, 'file')
             const upperCaseFilePath = filePath.toUpperCase()
 
-            await fs.writeFile(filePath, SAMPLE_CONTENT)
+            await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
 
             if (fs.caseSensitive) {
-                await expect(fs.stat(upperCaseFilePath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.stat(upperCaseFilePath)).to.be.rejectedWith('ENOENT')
             } else {
-                await expect((await fs.stat(upperCaseFilePath)).isFile()).to.equal(true)
+                await expect((await fs.promises.stat(upperCaseFilePath)).isFile()).to.equal(true)
             }
         })
 
@@ -624,9 +628,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                     fs: { path }
                 } = testInput
                 targetDirectoryPath = path.join(tempDirectoryPath, 'dir')
-                await fs.mkdir(targetDirectoryPath)
+                await fs.promises.mkdir(targetDirectoryPath)
                 sourceFilePath = path.join(tempDirectoryPath, SOURCE_FILE_NAME)
-                await fs.writeFile(sourceFilePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(sourceFilePath, SAMPLE_CONTENT)
             })
 
             it('can copy file', async () => {
@@ -636,9 +640,9 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const targetPath = path.join(targetDirectoryPath, SOURCE_FILE_NAME)
 
-                await fs.copyFile(sourceFilePath, targetPath)
+                await fs.promises.copyFile(sourceFilePath, targetPath)
 
-                expect(await fs.readFile(targetPath, 'utf8')).to.be.eql(SAMPLE_CONTENT)
+                expect(await fs.promises.readFile(targetPath, 'utf8')).to.be.eql(SAMPLE_CONTENT)
             })
 
             it('fails if source does not exist', async () => {
@@ -650,7 +654,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 const sourcePath = path.join(tempDirectoryPath, 'nonExistingFileName.txt')
                 const targetPath = path.join(targetDirectoryPath, SOURCE_FILE_NAME)
 
-                await expect(fs.copyFile(sourcePath, targetPath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.copyFile(sourcePath, targetPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('fails if target containing directory does not exist', async () => {
@@ -660,7 +664,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const targetPath = path.join(targetDirectoryPath, 'nonExistingDirectory', SOURCE_FILE_NAME)
 
-                await expect(fs.copyFile(sourceFilePath, targetPath)).to.be.rejectedWith('ENOENT')
+                await expect(fs.promises.copyFile(sourceFilePath, targetPath)).to.be.rejectedWith('ENOENT')
             })
 
             it('overwrites destination file by default', async () => {
@@ -670,10 +674,10 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const targetPath = path.join(targetDirectoryPath, SOURCE_FILE_NAME)
 
-                await fs.writeFile(targetPath, 'content to be overwritten')
-                await fs.copyFile(sourceFilePath, targetPath)
+                await fs.promises.writeFile(targetPath, 'content to be overwritten')
+                await fs.promises.copyFile(sourceFilePath, targetPath)
 
-                expect(await fs.readFile(targetPath, 'utf8')).to.be.eql(SAMPLE_CONTENT)
+                expect(await fs.promises.readFile(targetPath, 'utf8')).to.be.eql(SAMPLE_CONTENT)
             })
 
             it('fails if destination exists and flag COPYFILE_EXCL passed', async () => {
@@ -683,10 +687,10 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
                 } = testInput
                 const targetPath = path.join(targetDirectoryPath, SOURCE_FILE_NAME)
 
-                await fs.writeFile(targetPath, 'content to be overwritten')
+                await fs.promises.writeFile(targetPath, 'content to be overwritten')
 
                 await expect(
-                    fs.copyFile(sourceFilePath, targetPath, FileSystemConstants.COPYFILE_EXCL)
+                    fs.promises.copyFile(sourceFilePath, targetPath, FileSystemConstants.COPYFILE_EXCL)
                 ).to.be.rejectedWith('EEXIST')
             })
         })

--- a/packages/test-kit/src/async-fs-contract.ts
+++ b/packages/test-kit/src/async-fs-contract.ts
@@ -19,7 +19,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
                 await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
 
-                expect(await fs.fileExists(filePath)).to.equal(true)
+                expect(await fs.promises.fileExists(filePath)).to.equal(true)
             })
 
             it('returns false is path does not exist', async () => {
@@ -27,7 +27,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 const { join } = fs.path
                 const filePath = join(tempDirectoryPath, 'non-existing-file')
 
-                expect(await fs.fileExists(filePath)).to.equal(false)
+                expect(await fs.promises.fileExists(filePath)).to.equal(false)
             })
 
             it('returns false is path points to a directory', async () => {
@@ -37,7 +37,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
                 await fs.promises.mkdir(directoryPath)
 
-                expect(await fs.fileExists(directoryPath)).to.equal(false)
+                expect(await fs.promises.fileExists(directoryPath)).to.equal(false)
             })
         })
 
@@ -49,7 +49,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
                 await fs.promises.mkdir(directoryPath)
 
-                expect(await fs.directoryExists(directoryPath)).to.equal(true)
+                expect(await fs.promises.directoryExists(directoryPath)).to.equal(true)
             })
 
             it('returns false is path does not exist', async () => {
@@ -57,7 +57,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 const { join } = fs.path
                 const filePath = join(tempDirectoryPath, 'non-existing-directory')
 
-                expect(await fs.directoryExists(filePath)).to.equal(false)
+                expect(await fs.promises.directoryExists(filePath)).to.equal(false)
             })
 
             it('returns false is path points to a file', async () => {
@@ -67,7 +67,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
                 await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
 
-                expect(await fs.directoryExists(filePath)).to.equal(false)
+                expect(await fs.promises.directoryExists(filePath)).to.equal(false)
             })
         })
 
@@ -77,7 +77,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 const { join } = fs.path
                 const directoryPath = join(tempDirectoryPath, 'dir')
 
-                await fs.populateDirectory(directoryPath, {
+                await fs.promises.populateDirectory(directoryPath, {
                     'file1.ts': '',
                     'file2.ts': '',
                     folder1: {
@@ -92,9 +92,9 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                     }
                 })
 
-                await fs.remove(directoryPath)
+                await fs.promises.remove(directoryPath)
 
-                expect(await fs.directoryExists(directoryPath)).to.equal(false)
+                expect(await fs.promises.directoryExists(directoryPath)).to.equal(false)
             })
 
             it('should delete a file', async () => {
@@ -104,9 +104,9 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
                 await fs.promises.writeFile(filePath, '')
 
-                await fs.remove(filePath)
+                await fs.promises.remove(filePath)
 
-                expect(await fs.fileExists(tempDirectoryPath)).to.equal(false)
+                expect(await fs.promises.fileExists(tempDirectoryPath)).to.equal(false)
             })
 
             it('should fail on nonexistant', async () => {
@@ -114,7 +114,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 const { join } = fs.path
                 const filePath = await join(tempDirectoryPath, 'file')
 
-                return expect(fs.remove(filePath)).to.eventually.rejectedWith(/ENOENT/)
+                return expect(fs.promises.remove(filePath)).to.eventually.rejectedWith(/ENOENT/)
             })
         })
 
@@ -130,7 +130,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.populateDirectory(directoryPath, {
+                await fs.promises.populateDirectory(directoryPath, {
                     [fileName]: '',
                     folder1: {
                         [fileName]: ''
@@ -140,13 +140,13 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                     }
                 })
 
-                expect(await fs.findFiles(directoryPath)).to.eql([
+                expect(await fs.promises.findFiles(directoryPath)).to.eql([
                     path.join(directoryPath, fileName),
                     path.join(directoryPath, 'folder1', fileName),
                     path.join(directoryPath, 'folder2', anotherFileName)
                 ])
 
-                expect(await fs.findFiles(path.join(directoryPath, 'folder1'))).to.eql([
+                expect(await fs.promises.findFiles(path.join(directoryPath, 'folder1'))).to.eql([
                     path.join(directoryPath, 'folder1', fileName)
                 ])
             })
@@ -159,7 +159,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.populateDirectory(directoryPath, {
+                await fs.promises.populateDirectory(directoryPath, {
                     [fileName]: '',
                     folder1: {
                         [fileName]: ''
@@ -169,13 +169,12 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                     }
                 })
 
-                expect(await fs.findFiles(directoryPath, { filterFile: ({ name }) => name === fileName })).to.eql([
-                    path.join(directoryPath, fileName),
-                    path.join(directoryPath, 'folder1', fileName)
-                ])
+                expect(
+                    await fs.promises.findFiles(directoryPath, { filterFile: ({ name }) => name === fileName })
+                ).to.eql([path.join(directoryPath, fileName), path.join(directoryPath, 'folder1', fileName)])
 
                 expect(
-                    await fs.findFiles(directoryPath, { filterFile: ({ name }) => name === anotherFileName })
+                    await fs.promises.findFiles(directoryPath, { filterFile: ({ name }) => name === anotherFileName })
                 ).to.eql([path.join(directoryPath, 'folder2', anotherFileName)])
             })
 
@@ -187,7 +186,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.populateDirectory(directoryPath, {
+                await fs.promises.populateDirectory(directoryPath, {
                     [fileName]: '',
                     folder1: {
                         [fileName]: ''
@@ -197,13 +196,13 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                     }
                 })
 
-                expect(await fs.findFiles(directoryPath, { filterDirectory: ({ name }) => name === 'folder1' })).to.eql(
-                    [path.join(directoryPath, fileName), path.join(directoryPath, 'folder1', fileName)]
-                )
+                expect(
+                    await fs.promises.findFiles(directoryPath, { filterDirectory: ({ name }) => name === 'folder1' })
+                ).to.eql([path.join(directoryPath, fileName), path.join(directoryPath, 'folder1', fileName)])
 
-                expect(await fs.findFiles(directoryPath, { filterDirectory: ({ name }) => name === 'folder2' })).to.eql(
-                    [path.join(directoryPath, fileName), path.join(directoryPath, 'folder2', anotherFileName)]
-                )
+                expect(
+                    await fs.promises.findFiles(directoryPath, { filterDirectory: ({ name }) => name === 'folder2' })
+                ).to.eql([path.join(directoryPath, fileName), path.join(directoryPath, 'folder2', anotherFileName)])
             })
         })
 
@@ -216,7 +215,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.populateDirectory(directoryPath, {
+                await fs.promises.populateDirectory(directoryPath, {
                     [fileName]: '',
                     folder1: {
                         [fileName]: ''
@@ -226,17 +225,19 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                     }
                 })
 
-                expect(await fs.findClosestFile(path.join(directoryPath, 'folder1'), fileName)).to.equal(
+                expect(await fs.promises.findClosestFile(path.join(directoryPath, 'folder1'), fileName)).to.equal(
                     path.join(directoryPath, 'folder1', fileName)
                 )
 
-                expect(await fs.findClosestFile(directoryPath, fileName)).to.equal(path.join(directoryPath, fileName))
-
-                expect(await fs.findClosestFile(path.join(directoryPath, 'folder2'), anotherFileName)).to.equal(
-                    path.join(directoryPath, 'folder2', anotherFileName)
+                expect(await fs.promises.findClosestFile(directoryPath, fileName)).to.equal(
+                    path.join(directoryPath, fileName)
                 )
 
-                expect(await fs.findClosestFile(directoryPath, anotherFileName)).to.equal(null)
+                expect(
+                    await fs.promises.findClosestFile(path.join(directoryPath, 'folder2'), anotherFileName)
+                ).to.equal(path.join(directoryPath, 'folder2', anotherFileName))
+
+                expect(await fs.promises.findClosestFile(directoryPath, anotherFileName)).to.equal(null)
             })
         })
 
@@ -249,7 +250,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 } = testInput
                 const directoryPath = path.join(tempDirectoryPath, 'dir')
 
-                await fs.populateDirectory(directoryPath, {
+                await fs.promises.populateDirectory(directoryPath, {
                     [fileName]: '',
                     folder1: {
                         [fileName]: ''
@@ -259,14 +260,14 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                     }
                 })
 
-                expect(await fs.findFilesInAncestors(path.join(directoryPath, 'folder1'), fileName)).to.eql([
+                expect(await fs.promises.findFilesInAncestors(path.join(directoryPath, 'folder1'), fileName)).to.eql([
                     path.join(directoryPath, 'folder1', fileName),
                     path.join(directoryPath, fileName)
                 ])
 
-                expect(await fs.findFilesInAncestors(path.join(directoryPath, 'folder2'), anotherFileName)).to.eql([
-                    path.join(directoryPath, 'folder2', anotherFileName)
-                ])
+                expect(
+                    await fs.promises.findFilesInAncestors(path.join(directoryPath, 'folder2'), anotherFileName)
+                ).to.eql([path.join(directoryPath, 'folder2', anotherFileName)])
             })
         })
     })

--- a/packages/test-kit/src/async-fs-contract.ts
+++ b/packages/test-kit/src/async-fs-contract.ts
@@ -17,7 +17,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 const { join } = fs.path
                 const filePath = join(tempDirectoryPath, 'file')
 
-                await fs.writeFile(filePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
 
                 expect(await fs.fileExists(filePath)).to.equal(true)
             })
@@ -35,7 +35,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 const { join } = fs.path
                 const directoryPath = join(tempDirectoryPath, 'dir')
 
-                await fs.mkdir(directoryPath)
+                await fs.promises.mkdir(directoryPath)
 
                 expect(await fs.fileExists(directoryPath)).to.equal(false)
             })
@@ -47,7 +47,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 const { join } = fs.path
                 const directoryPath = join(tempDirectoryPath, 'dir')
 
-                await fs.mkdir(directoryPath)
+                await fs.promises.mkdir(directoryPath)
 
                 expect(await fs.directoryExists(directoryPath)).to.equal(true)
             })
@@ -65,7 +65,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 const { join } = fs.path
                 const filePath = join(tempDirectoryPath, 'file')
 
-                await fs.writeFile(filePath, SAMPLE_CONTENT)
+                await fs.promises.writeFile(filePath, SAMPLE_CONTENT)
 
                 expect(await fs.directoryExists(filePath)).to.equal(false)
             })
@@ -102,7 +102,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
                 const { join } = fs.path
                 const filePath = join(tempDirectoryPath, 'file')
 
-                await fs.writeFile(filePath, '')
+                await fs.promises.writeFile(filePath, '')
 
                 await fs.remove(filePath)
 

--- a/packages/types/src/base-api-async.ts
+++ b/packages/types/src/base-api-async.ts
@@ -1,11 +1,6 @@
-import { IFileSystemStats, BufferEncoding } from './common-fs-types'
+import { IFileSystemStats, BufferEncoding, IBuffer, CallbackFnVoid, CallbackFn } from './common-fs-types'
 import { IFileSystemPath } from './path'
 import { IWatchService } from './watch-api'
-
-// tslint:disable-next-line: interface-name
-declare interface Buffer {
-    toString(ecoding?: BufferEncoding): string
-}
 
 /**
  * ASYNC-only base file system.
@@ -16,45 +11,124 @@ export interface IBaseFileSystemAsync {
     watchService: IWatchService
     caseSensitive: boolean
 
+    promises: {
+        /**
+         * Copy `sourcePath` to `destinationPath`.
+         * By default, if destination already exists, it will be overwritten.
+         *
+         * @param flags passing `FileSystemConstants.COPYFILE_EXCL` will cause operation to fail if destination exists.
+         */
+        copyFile(sourcePath: string, destinationPath: string, flags?: number): Promise<void>
+
+        /**
+         * Read the entire contents of a file.
+         */
+        readFile(filePath: string): Promise<IBuffer>
+        readFile(filePath: string, encoding: BufferEncoding): Promise<string>
+
+        /**
+         * Write data to a file, replacing the file if already exists.
+         * `encoding` is used when a string `content` (not `IBuffer`) was provided (with default 'utf8').
+         */
+        writeFile(filePath: string, content: string | IBuffer, encoding?: BufferEncoding): Promise<void>
+
+        /**
+         * Delete a name and possibly the file it refers to.
+         */
+        unlink(filePath: string): Promise<void>
+
+        /**
+         * Read the names of items in a directory.
+         */
+        readdir(directoryPath: string): Promise<string[]>
+
+        /**
+         * Create a directory.
+         */
+        mkdir(directoryPath: string): Promise<void>
+
+        /**
+         * Delete a directory.
+         */
+        rmdir(directoryPath: string): Promise<void>
+
+        /**
+         * Check if a path points to an existing file/directory/link.
+         *
+         * @param path possible file path.
+         * @param statFn optional custom stat function (e.g. lstat to detect links).
+         */
+        exists(path: string): Promise<boolean>
+
+        /**
+         * Get path's `IFileSystemStats`.
+         */
+        stat(path: string): Promise<IFileSystemStats>
+
+        /**
+         * Get path's `IFileSystemStats`. Does not dereference symbolic links.
+         */
+        lstat(path: string): Promise<IFileSystemStats>
+
+        /**
+         * Gets the canonicalized absolute pathname.
+         * If path is linked, returns the actual target path.
+         */
+        realpath(path: string): Promise<string>
+
+        /**
+         * Rename (move) a file or a directory
+         */
+        rename(sourcePath: string, destinationPath: string): Promise<void>
+
+        /**
+         * Read value of a symbolic link.
+         */
+        readlink(path: string): Promise<IBuffer>
+        readlink(path: string, encoding: BufferEncoding): Promise<string>
+    }
+
     /**
      * Copy `sourcePath` to `destinationPath`.
      * By default, if destination already exists, it will be overwritten.
      *
      * @param flags passing `FileSystemConstants.COPYFILE_EXCL` will cause operation to fail if destination exists.
      */
-    copyFile(sourcePath: string, destinationPath: string, flags?: number): Promise<void>
+    copyFile(sourcePath: string, destinationPath: string, callback: CallbackFnVoid): void
+    copyFile(sourcePath: string, destinationPath: string, flags: number, callback: CallbackFnVoid): void
 
     /**
      * Read the entire contents of a file.
      */
-    readFile(filePath: string): Promise<Buffer>
-    readFile(filePath: string, encoding: BufferEncoding): Promise<string>
+    readFile(filePath: string, callback: CallbackFn<IBuffer>): void
+    readFile(filePath: string, encoding: BufferEncoding, callback: CallbackFn<string>): void
 
     /**
      * Write data to a file, replacing the file if already exists.
-     * `encoding` is used when a string `content` (not `Buffer`) was provided (with default 'utf8').
+     * `encoding` is used when a string `content` (not `IBuffer`) was provided (with default 'utf8').
      */
-    writeFile(filePath: string, content: string | Buffer, encoding?: BufferEncoding): Promise<void>
+    writeFile(filePath: string, content: string | IBuffer, callback: CallbackFnVoid): void
+    writeFile(filePath: string, content: string | IBuffer, encoding: BufferEncoding, callback: CallbackFnVoid): void
 
     /**
      * Delete a name and possibly the file it refers to.
      */
-    unlink(filePath: string): Promise<void>
+    unlink(filePath: string, callback: CallbackFnVoid): void
 
     /**
      * Read the names of items in a directory.
      */
-    readdir(directoryPath: string): Promise<string[]>
+    readdir(directoryPath: string, callback: CallbackFn<string[]>): void
 
     /**
      * Create a directory.
      */
-    mkdir(directoryPath: string): Promise<void>
+    mkdir(filePath: string, callback: CallbackFnVoid): void
 
     /**
      * Delete a directory.
      */
-    rmdir(directoryPath: string): Promise<void>
+    rmdir(filePath: string, callback: CallbackFnVoid): void
 
     /**
      * Check if a path points to an existing file/directory/link.
@@ -62,26 +136,32 @@ export interface IBaseFileSystemAsync {
      * @param path possible file path.
      * @param statFn optional custom stat function (e.g. lstat to detect links).
      */
-    exists(path: string): Promise<boolean>
+    exists(path: string, callback: (exists: boolean) => void): void
 
     /**
      * Get path's `IFileSystemStats`.
      */
-    stat(path: string): Promise<IFileSystemStats>
+    stat(path: string, callback: CallbackFn<IFileSystemStats>): void
 
     /**
      * Get path's `IFileSystemStats`. Does not dereference symbolic links.
      */
-    lstat(path: string): Promise<IFileSystemStats>
+    lstat(path: string, callback: CallbackFn<IFileSystemStats>): void
 
     /**
      * Gets the canonicalized absolute pathname.
      * If path is linked, returns the actual target path.
      */
-    realpath(path: string): Promise<string>
+    realpath(path: string, callback: CallbackFn<string>): void
 
     /**
      * Rename (move) a file or a directory
      */
-    rename(sourcePath: string, destinationPath: string): Promise<void>
+    rename(sourcePath: string, destinationPath: string, callback: CallbackFnVoid): void
+
+    /**
+     * Read value of a symbolic link.
+     */
+    readlink(path: string, callback: CallbackFn<IBuffer>): void
+    readlink(path: string, encoding: BufferEncoding, callback: CallbackFn<string>): void
 }

--- a/packages/types/src/base-api-async.ts
+++ b/packages/types/src/base-api-async.ts
@@ -1,8 +1,11 @@
-import { IFileSystemStats } from './common-fs-types'
+import { IFileSystemStats, BufferEncoding } from './common-fs-types'
 import { IFileSystemPath } from './path'
 import { IWatchService } from './watch-api'
 
-declare interface Buffer {} // tslint:disable-line
+// tslint:disable-next-line: interface-name
+declare interface Buffer {
+    toString(ecoding?: BufferEncoding): string
+}
 
 /**
  * ASYNC-only base file system.
@@ -25,13 +28,13 @@ export interface IBaseFileSystemAsync {
      * Read the entire contents of a file.
      */
     readFile(filePath: string): Promise<Buffer>
-    readFile(filePath: string, encoding: string): Promise<string>
+    readFile(filePath: string, encoding: BufferEncoding): Promise<string>
 
     /**
      * Write data to a file, replacing the file if already exists.
      * `encoding` is used when a string `content` (not `Buffer`) was provided (with default 'utf8').
      */
-    writeFile(filePath: string, content: string | Buffer, encoding?: string): Promise<void>
+    writeFile(filePath: string, content: string | Buffer, encoding?: BufferEncoding): Promise<void>
 
     /**
      * Delete a name and possibly the file it refers to.

--- a/packages/types/src/base-api-sync.ts
+++ b/packages/types/src/base-api-sync.ts
@@ -1,11 +1,6 @@
-import { IFileSystemStats, BufferEncoding } from './common-fs-types'
+import { IFileSystemStats, BufferEncoding, IBuffer } from './common-fs-types'
 import { IFileSystemPath } from './path'
 import { IWatchService } from './watch-api'
-
-// tslint:disable-next-line: interface-name
-declare interface Buffer {
-    toString(ecoding?: BufferEncoding): string
-}
 
 /**
  * SYNC-only base file system.
@@ -42,14 +37,14 @@ export interface IBaseFileSystemSync {
     /**
      * Read the entire contents of a file.
      */
-    readFileSync(filePath: string): Buffer
+    readFileSync(filePath: string): IBuffer
     readFileSync(filePath: string, encoding: BufferEncoding): string
 
     /**
      * Write data to a file, replacing the file if already exists.
-     * `encoding` is used when a string `content` (not `Buffer`) was provided (with default 'utf8').
+     * `encoding` is used when a string `content` (not `IBuffer`) was provided (with default 'utf8').
      */
-    writeFileSync(filePath: string, content: string | Buffer, encoding?: BufferEncoding): void
+    writeFileSync(filePath: string, content: string | IBuffer, encoding?: BufferEncoding): void
 
     /**
      * Delete a name and possibly the file it refers to.
@@ -99,4 +94,10 @@ export interface IBaseFileSystemSync {
      * Rename (move) a file or a directory
      */
     renameSync(sourcePath: string, destinationPath: string): void
+
+    /**
+     * Read value of a symbolic link.
+     */
+    readlinkSync(path: string): IBuffer
+    readlinkSync(path: string, encoding: BufferEncoding): string
 }

--- a/packages/types/src/base-api-sync.ts
+++ b/packages/types/src/base-api-sync.ts
@@ -1,8 +1,11 @@
-import { IFileSystemStats } from './common-fs-types'
+import { IFileSystemStats, BufferEncoding } from './common-fs-types'
 import { IFileSystemPath } from './path'
 import { IWatchService } from './watch-api'
 
-declare interface Buffer {} // tslint:disable-line
+// tslint:disable-next-line: interface-name
+declare interface Buffer {
+    toString(ecoding?: BufferEncoding): string
+}
 
 /**
  * SYNC-only base file system.
@@ -40,13 +43,13 @@ export interface IBaseFileSystemSync {
      * Read the entire contents of a file.
      */
     readFileSync(filePath: string): Buffer
-    readFileSync(filePath: string, encoding: string): string
+    readFileSync(filePath: string, encoding: BufferEncoding): string
 
     /**
      * Write data to a file, replacing the file if already exists.
      * `encoding` is used when a string `content` (not `Buffer`) was provided (with default 'utf8').
      */
-    writeFileSync(filePath: string, content: string | Buffer, encoding?: string): void
+    writeFileSync(filePath: string, content: string | Buffer, encoding?: BufferEncoding): void
 
     /**
      * Delete a name and possibly the file it refers to.

--- a/packages/types/src/common-fs-types.ts
+++ b/packages/types/src/common-fs-types.ts
@@ -2,6 +2,14 @@ export const POSIX_ROOT = '/'
 
 export type BufferEncoding = 'ascii' | 'utf8' | 'utf16le' | 'ucs2' | 'base64' | 'latin1' | 'binary' | 'hex'
 
+export interface IBuffer {
+    toString(ecoding?: BufferEncoding): string
+}
+
+export type CallbackFn<T> = (error: Error | null | undefined, value: T) => void
+export type CallbackFnVoid = (error: Error | null | undefined) => void
+export type ErrorCallbackFn = (error: Error) => void
+
 export enum FileSystemConstants {
     /**
      * When passed as a flag to `copyFile` or `copyFileSync`,

--- a/packages/types/src/common-fs-types.ts
+++ b/packages/types/src/common-fs-types.ts
@@ -1,5 +1,7 @@
 export const POSIX_ROOT = '/'
 
+export type BufferEncoding = 'ascii' | 'utf8' | 'utf16le' | 'ucs2' | 'base64' | 'latin1' | 'binary' | 'hex'
+
 export enum FileSystemConstants {
     /**
      * When passed as a flag to `copyFile` or `copyFileSync`,

--- a/packages/types/src/extended-api-async.ts
+++ b/packages/types/src/extended-api-async.ts
@@ -12,7 +12,7 @@ export interface IFileSystemAsync extends IBaseFileSystemAsync {
      * @param filePath possible file path
      * @param statFn optional custom stat function (e.g. lstat to detect links)
      */
-    fileExists(filePath: string, statFn?: IBaseFileSystemAsync['stat']): Promise<boolean>
+    fileExists(filePath: string, statFn?: IBaseFileSystemAsync['promises']['stat']): Promise<boolean>
 
     /**
      * Check if a path points to an existing directory.
@@ -20,7 +20,7 @@ export interface IFileSystemAsync extends IBaseFileSystemAsync {
      * @param directoryPath possible directory path
      * @param statFn optional custom stat function (e.g. lstatSync to detect links)
      */
-    directoryExists(directoryPath: string, statFn?: IBaseFileSystemAsync['stat']): Promise<boolean>
+    directoryExists(directoryPath: string, statFn?: IBaseFileSystemAsync['promises']['stat']): Promise<boolean>
 
     /**
      * Ensure that a directory and all its parent directories exist

--- a/packages/types/src/extended-api-async.ts
+++ b/packages/types/src/extended-api-async.ts
@@ -6,64 +6,66 @@ import { IBaseFileSystemAsync } from './base-api-async'
  * Exposes all base fs APIs plus several higher level methods.
  */
 export interface IFileSystemAsync extends IBaseFileSystemAsync {
-    /**
-     * Check if a path points to an existing file.
-     *
-     * @param filePath possible file path
-     * @param statFn optional custom stat function (e.g. lstat to detect links)
-     */
-    fileExists(filePath: string, statFn?: IBaseFileSystemAsync['promises']['stat']): Promise<boolean>
+    promises: IBaseFileSystemAsync['promises'] & {
+        /**
+         * Check if a path points to an existing file.
+         *
+         * @param filePath possible file path
+         * @param statFn optional custom stat function (e.g. lstat to detect links)
+         */
+        fileExists(filePath: string, statFn?: IBaseFileSystemAsync['promises']['stat']): Promise<boolean>
 
-    /**
-     * Check if a path points to an existing directory.
-     *
-     * @param directoryPath possible directory path
-     * @param statFn optional custom stat function (e.g. lstatSync to detect links)
-     */
-    directoryExists(directoryPath: string, statFn?: IBaseFileSystemAsync['promises']['stat']): Promise<boolean>
+        /**
+         * Check if a path points to an existing directory.
+         *
+         * @param directoryPath possible directory path
+         * @param statFn optional custom stat function (e.g. lstatSync to detect links)
+         */
+        directoryExists(directoryPath: string, statFn?: IBaseFileSystemAsync['promises']['stat']): Promise<boolean>
 
-    /**
-     * Ensure that a directory and all its parent directories exist
-     */
-    ensureDirectory(directoryPath: string): Promise<void>
+        /**
+         * Ensure that a directory and all its parent directories exist
+         */
+        ensureDirectory(directoryPath: string): Promise<void>
 
-    /**
-     * Search for files inside `rootDirectory`.
-     *
-     * @returns absolute paths of all found files.
-     */
-    findFiles(rootDirectory: string, options?: IWalkOptions): Promise<string[]>
+        /**
+         * Search for files inside `rootDirectory`.
+         *
+         * @returns absolute paths of all found files.
+         */
+        findFiles(rootDirectory: string, options?: IWalkOptions): Promise<string[]>
 
-    /**
-     * Search for a specific file name in parent directory chain.
-     * Useful for finding configuration or manifest files.
-     *
-     * @returns absolute path of first found file, or `null` if none found.
-     */
-    findClosestFile(initialDirectoryPath: string, fileName: string): Promise<string | null>
+        /**
+         * Search for a specific file name in parent directory chain.
+         * Useful for finding configuration or manifest files.
+         *
+         * @returns absolute path of first found file, or `null` if none found.
+         */
+        findClosestFile(initialDirectoryPath: string, fileName: string): Promise<string | null>
 
-    /**
-     * Search for a specific file name in parent chain.
-     * Useful for finding configuration or manifest files.
-     *
-     * @returns absolute paths of all found files (ordered from inner most directory and up).
-     */
-    findFilesInAncestors(initialDirectory: string, fileName: string): Promise<string[]>
+        /**
+         * Search for a specific file name in parent chain.
+         * Useful for finding configuration or manifest files.
+         *
+         * @returns absolute paths of all found files (ordered from inner most directory and up).
+         */
+        findFilesInAncestors(initialDirectory: string, fileName: string): Promise<string[]>
 
-    /**
-     * Populates the provided directory with given contents.
-     *
-     * @returns absolute paths of written files.
-     */
-    populateDirectory(directoryPath: string, contents: IDirectoryContents): Promise<string[]>
+        /**
+         * Populates the provided directory with given contents.
+         *
+         * @returns absolute paths of written files.
+         */
+        populateDirectory(directoryPath: string, contents: IDirectoryContents): Promise<string[]>
 
-    /**
-     * Recursively remove a path.
-     */
-    remove(path: string): Promise<void>
+        /**
+         * Recursively remove a path.
+         */
+        remove(path: string): Promise<void>
 
-    /**
-     * Recursively walk over a directory and its contents.
-     */
-    // walk(rootDirectory: string, options?: IWalkOptions): Promise<IFileSystemDescriptor[]>
+        /**
+         * Recursively walk over a directory and its contents.
+         */
+        // walk(rootDirectory: string, options?: IWalkOptions): Promise<IFileSystemDescriptor[]>
+    }
 }

--- a/packages/utils/src/callbackify.ts
+++ b/packages/utils/src/callbackify.ts
@@ -1,0 +1,37 @@
+import { CallbackFn, ErrorCallbackFn } from '@file-services/types'
+
+// ugly types until https://github.com/Microsoft/TypeScript/issues/5453 is resolved
+export function callbackify<T1, TResult>(fn: (arg1: T1) => TResult): (arg1: T1, callback: CallbackFn<TResult>) => void
+export function callbackify<T1, T2>(
+    fn: (arg1: T1, arg2: T2) => void
+): (arg1: T1, arg2: T2, callback: (err: Error | undefined | null) => void) => void
+export function callbackify<T1, T2, TResult>(
+    fn: (arg1: T1, arg2: T2) => TResult
+): (arg1: T1, arg2: T2, callback: CallbackFn<TResult>) => void
+export function callbackify<T1, T2, T3>(
+    fn: (arg1: T1, arg2: T2, arg3: T3) => void
+): (arg1: T1, arg2: T2, arg3: T3, callback: (err: Error | undefined | null) => void) => void
+export function callbackify<T1, T2, T3, TResult>(
+    fn: (arg1: T1, arg2: T2, arg3: T3) => TResult
+): (arg1: T1, arg2: T2, arg3: T3, callback: CallbackFn<TResult>) => void
+export function callbackify<T1, T2, T3, T4>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => void
+): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: Error | undefined | null) => void) => void
+export function callbackify<T1, T2, T3, T4, TResult>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
+): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: CallbackFn<TResult>) => void
+export function callbackify<F extends (...args: unknown[]) => unknown>(fn: F): unknown {
+    return ((...args: unknown[]): void => {
+        const callback = args.pop() as CallbackFn<unknown>
+        if (typeof callback !== 'function') {
+            return // no callback was passed, so do nothing
+        }
+        try {
+            const result = fn(...args)
+            callback(undefined, result)
+        } catch (e) {
+            // tslint:disable-next-line: semicolon
+            ;(callback as ErrorCallbackFn)(e)
+        }
+    }) as unknown
+}

--- a/packages/utils/src/create-extended-api.ts
+++ b/packages/utils/src/create-extended-api.ts
@@ -140,7 +140,10 @@ export function createSyncFileSystem(baseFs: IBaseFileSystemSync): IFileSystemSy
 }
 
 export function createAsyncFileSystem(baseFs: IBaseFileSystemAsync): IFileSystemAsync {
-    const { stat, path, mkdir, writeFile, lstat, rmdir, unlink, readdir } = baseFs
+    const {
+        path,
+        promises: { stat, mkdir, writeFile, lstat, rmdir, unlink, readdir }
+    } = baseFs
 
     async function fileExists(filePath: string, statFn = stat): Promise<boolean> {
         try {
@@ -258,13 +261,16 @@ export function createAsyncFileSystem(baseFs: IBaseFileSystemAsync): IFileSystem
 
     return {
         ...baseFs,
-        fileExists,
-        directoryExists,
-        ensureDirectory,
-        populateDirectory,
-        remove,
-        findFiles,
-        findClosestFile,
-        findFilesInAncestors
+        promises: {
+            ...baseFs.promises,
+            fileExists,
+            directoryExists,
+            ensureDirectory,
+            populateDirectory,
+            remove,
+            findFiles,
+            findClosestFile,
+            findFilesInAncestors
+        }
     }
 }

--- a/packages/utils/src/directory-fs.ts
+++ b/packages/utils/src/directory-fs.ts
@@ -4,7 +4,8 @@ import {
     WatchEventListener,
     IWatchService,
     IFileSystemPath,
-    POSIX_ROOT
+    POSIX_ROOT,
+    BufferEncoding
 } from '@file-services/types'
 import { createAsyncFileSystem, createSyncFileSystem } from './create-extended-api'
 
@@ -112,10 +113,10 @@ export function createDirectoryFs(fs: IFileSystem, directoryPath: string): IFile
         readdirSync(path) {
             return fs.readdirSync(resolveFullPath(path))
         },
-        async readFile(path: string, encoding?: string) {
+        async readFile(path: string, encoding?: BufferEncoding) {
             return fs.readFile(resolveFullPath(path), encoding!)
         },
-        readFileSync(path: string, encoding?: string) {
+        readFileSync(path: string, encoding?: BufferEncoding) {
             return fs.readFileSync(resolveFullPath(path), encoding!)
         },
         async realpath(path) {

--- a/packages/utils/src/directory-fs.ts
+++ b/packages/utils/src/directory-fs.ts
@@ -5,9 +5,14 @@ import {
     IWatchService,
     IFileSystemPath,
     POSIX_ROOT,
-    BufferEncoding
+    BufferEncoding,
+    CallbackFn,
+    IBuffer,
+    CallbackFnVoid
 } from '@file-services/types'
 import { createAsyncFileSystem, createSyncFileSystem } from './create-extended-api'
+
+type CbParams<T1, T2, T3 = T2> = [T1, T2] | [T3]
 
 /**
  * Creates a wrapped `IFileSystem` which scopes the provided `fs`
@@ -17,7 +22,7 @@ import { createAsyncFileSystem, createSyncFileSystem } from './create-extended-a
  * @param directoryPath the directory path to scope to
  */
 export function createDirectoryFs(fs: IFileSystem, directoryPath: string): IFileSystem {
-    const { watchService } = fs
+    const { watchService, promises } = fs
     const { join, relative, sep } = fs.path
     const posixPath = ((fs.path as any).posix as IFileSystemPath) || fs.path
 
@@ -89,77 +94,124 @@ export function createDirectoryFs(fs: IFileSystem, directoryPath: string): IFile
         chdir(path) {
             workingDirectoryPath = resolveScopedPath(path)
         },
-        async copyFile(src, dest, flags) {
-            return fs.copyFile(resolveFullPath(src), resolveFullPath(dest), flags)
+        promises: {
+            async copyFile(src, dest, flags) {
+                return promises.copyFile(resolveFullPath(src), resolveFullPath(dest), flags)
+            },
+            async lstat(path) {
+                return promises.lstat(resolveFullPath(path))
+            },
+            async mkdir(path) {
+                return promises.mkdir(resolveFullPath(path))
+            },
+            async readdir(path) {
+                return promises.readdir(resolveFullPath(path))
+            },
+            async readFile(path: string, encoding?: BufferEncoding) {
+                return promises.readFile(resolveFullPath(path), encoding!)
+            },
+            async realpath(path) {
+                return promises.realpath(resolveFullPath(path))
+            },
+            async rename(path, newPath) {
+                return promises.rename(resolveFullPath(path), resolveFullPath(newPath))
+            },
+            async rmdir(path) {
+                return promises.rmdir(resolveFullPath(path))
+            },
+            async exists(path) {
+                return promises.exists(resolveFullPath(path))
+            },
+            async stat(path) {
+                return promises.stat(resolveFullPath(path))
+            },
+            async unlink(path) {
+                return promises.unlink(resolveFullPath(path))
+            },
+            async writeFile(path, content, encoding) {
+                return promises.writeFile(resolveFullPath(path), content, encoding)
+            },
+            async readlink(path: string, encoding?: BufferEncoding) {
+                return promises.readlink(resolveFullPath(path), encoding!)
+            }
         },
         copyFileSync(src, dest, flags) {
             return fs.copyFileSync(resolveFullPath(src), resolveFullPath(dest), flags)
         },
-        async lstat(path) {
-            return fs.lstat(resolveFullPath(path))
-        },
         lstatSync(path) {
             return fs.lstatSync(resolveFullPath(path))
-        },
-        async mkdir(path) {
-            return fs.mkdir(resolveFullPath(path))
         },
         mkdirSync(path) {
             return fs.mkdirSync(resolveFullPath(path))
         },
-        async readdir(path) {
-            return fs.readdir(resolveFullPath(path))
-        },
         readdirSync(path) {
             return fs.readdirSync(resolveFullPath(path))
-        },
-        async readFile(path: string, encoding?: BufferEncoding) {
-            return fs.readFile(resolveFullPath(path), encoding!)
         },
         readFileSync(path: string, encoding?: BufferEncoding) {
             return fs.readFileSync(resolveFullPath(path), encoding!)
         },
-        async realpath(path) {
-            return fs.realpath(resolveFullPath(path))
-        },
         realpathSync(path) {
             return fs.realpathSync(resolveFullPath(path))
         },
-        async rename(path, newPath) {
-            return fs.rename(resolveFullPath(path), resolveFullPath(newPath))
+        readlinkSync(path: string, encoding?: BufferEncoding) {
+            return fs.readlinkSync(resolveFullPath(path), encoding!)
         },
         renameSync(path, newPath) {
             return fs.renameSync(resolveFullPath(path), resolveFullPath(newPath))
         },
-        async rmdir(path) {
-            return fs.rmdir(resolveFullPath(path))
-        },
         rmdirSync(path) {
             return fs.rmdirSync(resolveFullPath(path))
-        },
-        async exists(path) {
-            return fs.exists(resolveFullPath(path))
         },
         existsSync(path) {
             return fs.existsSync(resolveFullPath(path))
         },
-        async stat(path) {
-            return fs.stat(resolveFullPath(path))
-        },
         statSync(path) {
             return fs.statSync(resolveFullPath(path))
-        },
-        async unlink(path) {
-            return fs.unlink(resolveFullPath(path))
         },
         unlinkSync(path) {
             return fs.unlinkSync(resolveFullPath(path))
         },
-        async writeFile(path, content, encoding) {
-            return fs.writeFile(resolveFullPath(path), content, encoding)
-        },
         writeFileSync(path, content, encoding) {
             return fs.writeFileSync(resolveFullPath(path), content, encoding)
+        },
+        copyFile(src: string, dest: string, ...restArgs: CbParams<number, CallbackFnVoid>) {
+            fs.copyFile(resolveFullPath(src), resolveFullPath(dest), ...(restArgs as [CallbackFnVoid]))
+        },
+        lstat(path, callback) {
+            fs.lstat(resolveFullPath(path), callback)
+        },
+        mkdir(path, callback) {
+            fs.mkdir(resolveFullPath(path), callback)
+        },
+        readdir(path, callback) {
+            return fs.readdir(resolveFullPath(path), callback)
+        },
+        readFile(path: string, ...restArgs: CbParams<BufferEncoding, CallbackFn<string>, CallbackFn<IBuffer>>) {
+            return fs.readFile(resolveFullPath(path), ...(restArgs as [CallbackFn<IBuffer>]))
+        },
+        realpath(path, callback) {
+            return fs.realpath(resolveFullPath(path), callback)
+        },
+        rename(path, newPath, callback) {
+            return fs.rename(resolveFullPath(path), resolveFullPath(newPath), callback)
+        },
+        rmdir(path, callback) {
+            return fs.rmdir(resolveFullPath(path), callback)
+        },
+        exists(path, callback) {
+            return fs.exists(resolveFullPath(path), callback)
+        },
+        stat(path, callback) {
+            return fs.stat(resolveFullPath(path), callback)
+        },
+        unlink(path, callback) {
+            return fs.unlink(resolveFullPath(path), callback)
+        },
+        writeFile(path: string, contents: string | IBuffer, ...restArgs: CbParams<BufferEncoding, CallbackFnVoid>) {
+            return fs.writeFile(resolveFullPath(path), contents, ...(restArgs as [CallbackFnVoid]))
+        },
+        readlink(path: string, ...restArgs: CbParams<BufferEncoding, CallbackFn<string>, CallbackFn<IBuffer>>) {
+            return fs.readlink(resolveFullPath(path), ...(restArgs as [CallbackFn<IBuffer>]))
         }
     }
 

--- a/packages/utils/src/sync-to-async-fs.ts
+++ b/packages/utils/src/sync-to-async-fs.ts
@@ -1,4 +1,4 @@
-import { IBaseFileSystemSync, IBaseFileSystemAsync } from '@file-services/types'
+import { IBaseFileSystemSync, IBaseFileSystemAsync, BufferEncoding } from '@file-services/types'
 
 export function syncToAsyncFs(syncFs: IBaseFileSystemSync): IBaseFileSystemAsync {
     return {
@@ -6,7 +6,7 @@ export function syncToAsyncFs(syncFs: IBaseFileSystemSync): IBaseFileSystemAsync
         watchService: syncFs.watchService,
         caseSensitive: syncFs.caseSensitive,
 
-        async readFile(filePath: string, encoding?: string) {
+        async readFile(filePath: string, encoding?: BufferEncoding) {
             return syncFs.readFileSync(filePath, encoding!)
         },
 

--- a/packages/utils/src/sync-to-async-fs.ts
+++ b/packages/utils/src/sync-to-async-fs.ts
@@ -1,4 +1,5 @@
 import { IBaseFileSystemSync, IBaseFileSystemAsync, BufferEncoding } from '@file-services/types'
+import { callbackify } from './callbackify'
 
 export function syncToAsyncFs(syncFs: IBaseFileSystemSync): IBaseFileSystemAsync {
     return {
@@ -6,52 +7,74 @@ export function syncToAsyncFs(syncFs: IBaseFileSystemSync): IBaseFileSystemAsync
         watchService: syncFs.watchService,
         caseSensitive: syncFs.caseSensitive,
 
-        async readFile(filePath: string, encoding?: BufferEncoding) {
-            return syncFs.readFileSync(filePath, encoding!)
+        promises: {
+            async readFile(filePath: string, encoding?: BufferEncoding) {
+                return syncFs.readFileSync(filePath, encoding!)
+            },
+
+            async writeFile(filePath, content, encoding) {
+                return syncFs.writeFileSync(filePath, content, encoding)
+            },
+
+            async unlink(filePath) {
+                return syncFs.unlinkSync(filePath)
+            },
+
+            async readdir(directoryPath) {
+                return syncFs.readdirSync(directoryPath)
+            },
+
+            async mkdir(directoryPath) {
+                return syncFs.mkdirSync(directoryPath)
+            },
+
+            async rmdir(directoryPath) {
+                return syncFs.rmdirSync(directoryPath)
+            },
+
+            async exists(nodePath) {
+                return syncFs.existsSync(nodePath)
+            },
+
+            async stat(nodePath) {
+                return syncFs.statSync(nodePath)
+            },
+
+            async lstat(nodePath) {
+                return syncFs.lstatSync(nodePath)
+            },
+
+            async realpath(nodePath) {
+                return syncFs.realpathSync(nodePath)
+            },
+
+            async rename(path, newPath) {
+                return syncFs.renameSync(path, newPath)
+            },
+
+            async copyFile(src, dest, flags) {
+                return syncFs.copyFileSync(src, dest, flags)
+            },
+
+            async readlink(path: string, encoding?: BufferEncoding) {
+                return syncFs.readlinkSync(path, encoding!)
+            }
         },
 
-        async writeFile(filePath, content, encoding) {
-            return syncFs.writeFileSync(filePath, content, encoding)
+        exists(nodePath, callback) {
+            callback(syncFs.existsSync(nodePath))
         },
-
-        async unlink(filePath) {
-            return syncFs.unlinkSync(filePath)
-        },
-
-        async readdir(directoryPath) {
-            return syncFs.readdirSync(directoryPath)
-        },
-
-        async mkdir(directoryPath) {
-            return syncFs.mkdirSync(directoryPath)
-        },
-
-        async rmdir(directoryPath) {
-            return syncFs.rmdirSync(directoryPath)
-        },
-
-        async exists(nodePath) {
-            return syncFs.existsSync(nodePath)
-        },
-
-        async stat(nodePath) {
-            return syncFs.statSync(nodePath)
-        },
-
-        async lstat(nodePath) {
-            return syncFs.lstatSync(nodePath)
-        },
-
-        async realpath(nodePath) {
-            return syncFs.realpathSync(nodePath)
-        },
-
-        async rename(path, newPath) {
-            return syncFs.renameSync(path, newPath)
-        },
-
-        async copyFile(src, dest, flags) {
-            return syncFs.copyFileSync(src, dest, flags)
-        }
+        readFile: callbackify(syncFs.readFileSync) as IBaseFileSystemAsync['readFile'],
+        writeFile: callbackify(syncFs.writeFileSync) as IBaseFileSystemAsync['writeFile'],
+        unlink: callbackify(syncFs.unlinkSync),
+        readdir: callbackify(syncFs.readdirSync),
+        mkdir: callbackify(syncFs.mkdirSync),
+        rmdir: callbackify(syncFs.rmdirSync),
+        stat: callbackify(syncFs.statSync),
+        lstat: callbackify(syncFs.lstatSync),
+        realpath: callbackify(syncFs.realpathSync),
+        rename: callbackify(syncFs.renameSync),
+        copyFile: callbackify(syncFs.copyFileSync) as IBaseFileSystemAsync['copyFile'],
+        readlink: callbackify(syncFs.readlinkSync) as IBaseFileSystemAsync['readlink']
     }
 }

--- a/packages/utils/test/directory-fs.spec.ts
+++ b/packages/utils/test/directory-fs.spec.ts
@@ -23,15 +23,15 @@ describe('createDirectoryFs', () => {
         const fs = createDirectoryFs(createPreloadedMemFs(), scopedDirectoryPath)
         const filePath = '/src/index.ts'
 
-        expect((await fs.stat(filePath)).isFile()).to.equal(true)
-        expect(await fs.readFile(filePath)).to.eql(SAMPLE_CONTENT)
+        expect((await fs.promises.stat(filePath)).isFile()).to.equal(true)
+        expect(await fs.promises.readFile(filePath)).to.eql(SAMPLE_CONTENT)
     })
 
     it('cannot use a relative path to access a file outside of the scoped directory path', async () => {
         const fs = createDirectoryFs(createPreloadedMemFs(), scopedDirectoryPath)
         const filePath = '../outside-scope-file.ts'
 
-        await expect(fs.readFile(filePath)).to.be.rejectedWith(
+        await expect(fs.promises.readFile(filePath)).to.be.rejectedWith(
             `/test-directory/outside-scope-file.ts ENOENT: no such file`
         )
     })
@@ -40,7 +40,7 @@ describe('createDirectoryFs', () => {
         const fs = createDirectoryFs(createPreloadedMemFs(), scopedDirectoryPath)
         const filePath = '/outside-scope-file.ts'
 
-        await expect(fs.readFile(filePath)).to.be.rejectedWith(`ENOENT`)
+        await expect(fs.promises.readFile(filePath)).to.be.rejectedWith(`ENOENT`)
     })
 
     const testProvider = async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,14 +753,14 @@
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
 "@types/node@*":
-  version "11.11.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.0.tgz#070e9ce7c90e727aca0e0c14e470f9a93ffe9390"
-  integrity sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg==
+  version "10.12.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
+  integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
-"@types/node@8":
-  version "8.10.43"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.43.tgz#8d3281a33c92a56038b05d9460a65bc1dcd5735b"
-  integrity sha512-5m5W13HR2k3cu88mpzlnPBBv5+GyMHtj4F0P83RG4mqoC0AYVYHVMHfF3SgwKNtqEZiZQASMxU92QsLEekKcnw==
+"@types/node@10":
+  version "10.12.29"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.29.tgz#c2c8d2d27bb55649fbafe8ea1731658421f38acf"
+  integrity sha512-J/tnbnj8HcsBgCe2apZbdUpQ7hs4d7oZNTYA5bekWdP0sr2NGsOpI/HRdDroEi209tEvTcTtxhD0FfED3DhEcw==
 
 "@types/prop-types@*":
   version "15.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,9 +753,9 @@
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
 "@types/node@*":
-  version "10.12.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
-  integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
+  version "10.12.19"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.19.tgz#ca1018c26be01f07e66ac7fefbeb6407e4490c61"
+  integrity sha512-2NVovndCjJQj6fUUn9jCgpP4WSqr+u1SoUZMZyJkhGeBFsm6dE46l31S7lPUYt9uQ28XI+ibrJA1f5XyH5HNtA==
 
 "@types/node@10":
   version "10.12.29"


### PR DESCRIPTION
- Drop node 8 support.
- Exposes all promise-based API under `promises` field (matches Node 10+).
- Node package uses Node 10's native `promises` API instead of promisifying them every time via `proper-fs`.
- Callback-style API is now exposed as well from async file systems.
- `readlink` (promise and callback style) and `readlinkSync` is now exposed as well, for better compatibility with libraries expecting Node-style API.

closes #14