### PR TITLE
node: re-enable directory removal test

### DIFF
--- a/packages/node/test/watch-service.spec.ts
+++ b/packages/node/test/watch-service.spec.ts
@@ -78,9 +78,8 @@ describe('Node Watch Service', function() {
             await mkdir(testDirectoryPath);
         });
 
-        // fails on Mac. should be investigated. possibly node/libuv bug.
-        it.skip('fires a watch event when a watched directory is removed', async () => {
-            await watchService.watchPath(testDirectoryPath);
+        it('fires a watch event when a watched directory is removed', async () => {
+            await watchService.watchPath(tempDir.path);
 
             await rmdir(testDirectoryPath);
 


### PR DESCRIPTION
watching parent directory gives watch events for child directories being deleted