### PR TITLE
refactor: ensureDirectory behavior/tests cleanups

### DIFF
--- a/packages/test-kit/src/async-fs-contract.ts
+++ b/packages/test-kit/src/async-fs-contract.ts
@@ -352,7 +352,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
         await fs.promises.writeFile(filePath, '🦇');
 
         const directoryPath = fs.join(filePath, 'some-directory');
-        await expect(fs.promises.ensureDirectory(directoryPath)).to.eventually.be.rejectedWith('EEXIST');
+        await expect(fs.promises.ensureDirectory(directoryPath)).to.eventually.be.rejectedWith(/ENOTDIR|EEXIST/);
       });
     });
   });

--- a/packages/test-kit/src/sync-fs-contract.ts
+++ b/packages/test-kit/src/sync-fs-contract.ts
@@ -350,7 +350,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
         fs.writeFileSync(filePath, '🦇');
 
         const directoryPath = fs.join(filePath, 'some-directory');
-        expect(() => fs.ensureDirectorySync(directoryPath)).to.throw('EEXIST'); // posix / windows
+        expect(() => fs.ensureDirectorySync(directoryPath)).to.throw(/ENOTDIR|EEXIST/);
       });
 
       it('handles special paths gracefully', () => {

--- a/packages/utils/src/create-extended-api.ts
+++ b/packages/utils/src/create-extended-api.ts
@@ -74,8 +74,16 @@ export function createExtendedSyncActions(baseFs: IBaseFileSystemSync): IFileSys
       mkdirSync(directoryPath);
     } catch (e) {
       const code = (e as NodeJS.ErrnoException)?.code;
-      if (code === 'EISDIR' || (code === 'EEXIST' && statSync(directoryPath).isDirectory())) {
+      if (code === 'EISDIR') {
         return;
+      } else if (code === 'EEXIST') {
+        if (directoryExistsSync(directoryPath)) {
+          return;
+        } else {
+          throw e;
+        }
+      } else if (code === 'ENOTDIR' || !code) {
+        throw e;
       }
 
       const parentPath = dirname(directoryPath);
@@ -88,8 +96,7 @@ export function createExtendedSyncActions(baseFs: IBaseFileSystemSync): IFileSys
         mkdirSync(directoryPath);
       } catch (e) {
         const code = (e as NodeJS.ErrnoException)?.code;
-        const isDirectoryExistsError =
-          code === 'EISDIR' || (code === 'EEXIST' && statSync(directoryPath).isDirectory());
+        const isDirectoryExistsError = code === 'EISDIR' || (code === 'EEXIST' && directoryExistsSync(directoryPath));
         if (!isDirectoryExistsError) {
           throw e;
         }
@@ -263,9 +270,18 @@ export function createExtendedFileSystemPromiseActions(
       await mkdir(directoryPath);
     } catch (e) {
       const code = (e as NodeJS.ErrnoException)?.code;
-      if (code === 'EISDIR' || (code === 'EEXIST' && (await stat(directoryPath)).isDirectory())) {
+      if (code === 'EISDIR') {
         return;
+      } else if (code === 'EEXIST') {
+        if (await directoryExists(directoryPath)) {
+          return;
+        } else {
+          throw e;
+        }
+      } else if (code === 'ENOTDIR' || !code) {
+        throw e;
       }
+
       const parentPath = dirname(directoryPath);
       if (parentPath === directoryPath) {
         throw e;
@@ -277,7 +293,7 @@ export function createExtendedFileSystemPromiseActions(
       } catch (e) {
         const code = (e as NodeJS.ErrnoException)?.code;
         const isDirectoryExistsError =
-          code === 'EISDIR' || (code === 'EEXIST' && (await stat(directoryPath)).isDirectory());
+          code === 'EISDIR' || (code === 'EEXIST' && (await directoryExists(directoryPath)));
         if (!isDirectoryExistsError) {
           throw e;
         }

--- a/packages/utils/src/create-extended-api.ts
+++ b/packages/utils/src/create-extended-api.ts
@@ -73,13 +73,9 @@ export function createExtendedSyncActions(baseFs: IBaseFileSystemSync): IFileSys
     try {
       mkdirSync(directoryPath);
     } catch (e) {
-      if (directoryExistsSync(directoryPath)) {
+      const code = (e as NodeJS.ErrnoException)?.code;
+      if (code === 'EISDIR' || (code === 'EEXIST' && statSync(directoryPath).isDirectory())) {
         return;
-      }
-
-      // Propagate the error, unless it's caused by missing the parent dir (ENOENT).
-      if (!e || (e as NodeJS.ErrnoException).code !== 'ENOENT') {
-        throw e;
       }
 
       const parentPath = dirname(directoryPath);
@@ -87,17 +83,14 @@ export function createExtendedSyncActions(baseFs: IBaseFileSystemSync): IFileSys
         throw e;
       }
 
-      // Windows also throws ENOENT when trying to create a directory inside of a file,
-      // unlike Mac/Linux that throw ENOTDIR.
-      if (fileExistsSync(parentPath)) {
-        throw e;
-      }
-
       ensureDirectorySync(parentPath);
       try {
         mkdirSync(directoryPath);
       } catch (e) {
-        if (!directoryExistsSync(directoryPath)) {
+        const code = (e as NodeJS.ErrnoException)?.code;
+        const isDirectoryExistsError =
+          code === 'EISDIR' || (code === 'EEXIST' && statSync(directoryPath).isDirectory());
+        if (!isDirectoryExistsError) {
           throw e;
         }
       }
@@ -269,18 +262,23 @@ export function createExtendedFileSystemPromiseActions(
     try {
       await mkdir(directoryPath);
     } catch (e) {
-      if (e && ((e as NodeJS.ErrnoException).code === 'EEXIST' || (e as NodeJS.ErrnoException).code === 'EISDIR')) {
+      const code = (e as NodeJS.ErrnoException)?.code;
+      if (code === 'EISDIR' || (code === 'EEXIST' && (await stat(directoryPath)).isDirectory())) {
         return;
       }
       const parentPath = dirname(directoryPath);
       if (parentPath === directoryPath) {
         throw e;
       }
+
       await ensureDirectory(parentPath);
       try {
         await mkdir(directoryPath);
       } catch (e) {
-        if (!e || ((e as NodeJS.ErrnoException).code !== 'EEXIST' && (e as NodeJS.ErrnoException).code !== 'EISDIR')) {
+        const code = (e as NodeJS.ErrnoException)?.code;
+        const isDirectoryExistsError =
+          code === 'EISDIR' || (code === 'EEXIST' && (await stat(directoryPath)).isDirectory());
+        if (!isDirectoryExistsError) {
           throw e;
         }
       }


### PR DESCRIPTION
Behavior:
- more specific `error.code` checks. avoiding extra fs calls, with more errors being propagated.
- still room for improvement. could try and see if `error.code` for non-existing parent is consistent between platforms, and only ensure parent if that code was thrown.

Tests:
- test async variant (`ensureDirectory`) as well.
- avoid using `populateDirectory` during tests (it uses `ensureDirectory` on its own!).
- simplify tests for easier reading. no more trying to map objects to textual paths.
- avoid testing the stuff don't happen (file isn't being deleted; content is kept). these assertions are acceptable as regression tests (not this case). otherwise, one could test virtually anything (new directory is empty, etc).