### PR TITLE
resolve: statSync instead of file/directoryExists

### DIFF
--- a/packages/resolve/src/types.ts
+++ b/packages/resolve/src/types.ts
@@ -53,12 +53,12 @@ export type RequestResolver = (contextPath: string, request: string) => IResolut
  * Currently a subset of the sync base file system API.
  */
 export interface IResolutionFileSystem {
+  statSync(path: string): { isFile(): boolean; isDirectory(): boolean; birthtime: Date; mtime: Date };
+  readFileSync(path: string, encoding: 'utf8'): string;
+  realpathSync(path: string): string;
+
   dirname(path: string): string;
   join(...paths: string[]): string;
   resolve(...pathSegments: string[]): string;
   isAbsolute(path: string): boolean;
-  fileExistsSync(path: string): boolean;
-  directoryExistsSync(path: string): boolean;
-  readFileSync(path: string, encoding: 'utf8'): string;
-  realpathSync(path: string): string;
 }


### PR DESCRIPTION
- Using it directly allows native node fs to be provided `{ ...fs, ...path }`.
- Makes it possible to do a self validating cache.