### PR TITLE
feat: implement symlinkSync and promises.symlink

### DIFF
--- a/packages/cached/src/cached-fs.ts
+++ b/packages/cached/src/cached-fs.ts
@@ -84,6 +84,11 @@ export function createCachedFs(fs: IFileSystem): ICachedFileSystem {
         invalidateAbsolute(directoryPath);
         return fs.rmdirSync(directoryPath);
       },
+      symlinkSync(target, path, type) {
+        path = fs.resolve(path);
+        invalidateAbsolute(path);
+        return fs.symlinkSync(target, path, type);
+      },
       unlink(filePath, callback) {
         filePath = fs.resolve(filePath);
         invalidateAbsolute(filePath);
@@ -247,6 +252,11 @@ export function createCachedFs(fs: IFileSystem): ICachedFileSystem {
           statsCache.set(cacheKey, { kind: 'failure', error: e as Error });
           throw e;
         }
+      },
+      symlink(target, path, type) {
+        path = fs.resolve(path);
+        invalidateAbsolute(path);
+        return promises.symlink(target, path, type);
       },
     },
   };

--- a/packages/memory/src/error-codes.ts
+++ b/packages/memory/src/error-codes.ts
@@ -5,6 +5,7 @@ export enum FsErrorCodes {
 
   PATH_IS_FILE = 'ENOTDIR: path points to a file',
   PATH_IS_DIRECTORY = 'EISDIR: path points to a directory',
+  PATH_IS_INVALID = 'EINVAL: invalid argument',
 
   CONTAINING_NOT_EXISTS = 'ENOENT: containing directory does not exist',
   DIRECTORY_NOT_EMPTY = 'ENOTEMPTY: directory is not empty',

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -18,11 +18,13 @@ export interface IBaseMemFileSystemSync extends IBaseFileSystemSync {
 }
 
 export interface IFsMemNode {
-  type: 'file' | 'dir';
+  type: 'file' | 'dir' | 'symlink';
   name: string;
   birthtime: Date;
   mtime: Date;
 }
+
+export type IFsMemNodeType = IFsMemFileNode | IFsMemDirectoryNode | IFsMemSymlinkNode;
 
 export interface IFsMemFileNode extends IFsMemNode {
   type: 'file';
@@ -31,5 +33,10 @@ export interface IFsMemFileNode extends IFsMemNode {
 
 export interface IFsMemDirectoryNode extends IFsMemNode {
   type: 'dir';
-  contents: Map<string, IFsMemDirectoryNode | IFsMemFileNode>;
+  contents: Map<string, IFsMemNodeType>;
+}
+
+export interface IFsMemSymlinkNode extends IFsMemNode {
+  type: 'symlink';
+  target: string;
 }

--- a/packages/test-kit/src/sync-base-fs-contract.ts
+++ b/packages/test-kit/src/sync-base-fs-contract.ts
@@ -790,7 +790,7 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
         const linkPath = fs.join(tempDirectoryPath, LINK_NAME);
         fs.mkdirSync(linkPath);
 
-        expect(() => fs.symlinkSync(targetPath, linkPath)).to.throw('EEXIST');
+        expect(() => fs.symlinkSync(targetPath, linkPath, 'junction')).to.throw('EEXIST');
       });
     });
   });

--- a/packages/test-kit/src/sync-base-fs-contract.ts
+++ b/packages/test-kit/src/sync-base-fs-contract.ts
@@ -786,8 +786,9 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
       it('fails creating a link over an existing directory', () => {
         const { fs, tempDirectoryPath } = testInput;
         const targetPath = fs.join(tempDirectoryPath, TARGET_NAME);
-        fs.writeFileSync(targetPath, SAMPLE_CONTENT);
         const linkPath = fs.join(tempDirectoryPath, LINK_NAME);
+
+        fs.mkdirSync(targetPath);
         fs.mkdirSync(linkPath);
 
         expect(() => fs.symlinkSync(targetPath, linkPath, 'junction')).to.throw('EEXIST');

--- a/packages/types/src/base-api-async.ts
+++ b/packages/types/src/base-api-async.ts
@@ -195,4 +195,9 @@ export interface IBaseFileSystemPromiseActions {
    * Read value of a symbolic link.
    */
   readlink(path: string): Promise<string>;
+
+  /**
+   * Creates a symbolic link for `target` at `path`. default type is 'file'.
+   */
+  symlink(target: string, path: string, type?: 'dir' | 'file' | 'junction'): Promise<void>;
 }

--- a/packages/types/src/base-api-sync.ts
+++ b/packages/types/src/base-api-sync.ts
@@ -111,4 +111,9 @@ export interface IBaseFileSystemSyncActions {
    * Read value of a symbolic link.
    */
   readlinkSync(path: string): string;
+
+  /**
+   * Creates a symbolic link for `target` at `path`. default type is 'file'.
+   */
+  symlinkSync(target: string, path: string, type?: 'dir' | 'file' | 'junction'): void;
 }

--- a/packages/utils/src/sync-to-async-fs.ts
+++ b/packages/utils/src/sync-to-async-fs.ts
@@ -11,53 +11,44 @@ export function syncToAsyncFs(syncFs: IBaseFileSystemSync): IBaseFileSystemAsync
       readFile: async function readFile(...args: [string]) {
         return syncFs.readFileSync(...args);
       } as IBaseFileSystemPromiseActions['readFile'],
-
       async writeFile(...args) {
         return syncFs.writeFileSync(...args);
       },
-
       async unlink(filePath) {
         return syncFs.unlinkSync(filePath);
       },
-
       readdir: async function readdir(...args: [string]) {
         return syncFs.readdirSync(...args);
       } as IBaseFileSystemPromiseActions['readdir'],
-
       async mkdir(directoryPath, ...args) {
         return syncFs.mkdirSync(directoryPath, ...args);
       },
-
       async rmdir(directoryPath) {
         return syncFs.rmdirSync(directoryPath);
       },
-
       async exists(nodePath) {
         return syncFs.existsSync(nodePath);
       },
-
       async stat(nodePath) {
         return syncFs.statSync(nodePath);
       },
-
       async lstat(nodePath) {
         return syncFs.lstatSync(nodePath);
       },
-
       async realpath(nodePath) {
         return syncFs.realpathSync(nodePath);
       },
-
       async rename(srcPath, destPath) {
         return syncFs.renameSync(srcPath, destPath);
       },
-
       async copyFile(...args) {
         return syncFs.copyFileSync(...args);
       },
-
       async readlink(path) {
         return syncFs.readlinkSync(path);
+      },
+      async symlink(...args) {
+        return syncFs.symlinkSync(...args);
       },
     },
     exists(nodePath, callback) {


### PR DESCRIPTION
- fix directory fs's handling of links pointing outside the directory.
- add contract tests to verify symlink behaviors.
- correct handling of readlink vs realpath in various places.
- avoid resoving relative link paths. happens every time a link is dereferenced.

builds upon the work at #153. further optimizes memory-fs's operation, supports/retains relative links, and fixes link handling in directory fs.