### PR TITLE
perf: optimize memory fs's stats handling

### DIFF
--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -4,6 +4,7 @@ import type {
   IFileSystemAsync,
   IFileSystemSync,
   IFileSystemStats,
+  IDirectoryEntry,
 } from '@file-services/types';
 
 export interface IMemFileSystem extends IFileSystemSync, IFileSystemAsync {
@@ -18,10 +19,11 @@ export interface IBaseMemFileSystemSync extends IBaseFileSystemSync {
   root: IFsMemDirectoryNode;
 }
 
+export interface IFsMemStatsEntry extends IFileSystemStats, IDirectoryEntry {}
+
 export interface IFsMemNode {
   type: 'file' | 'dir' | 'symlink';
-  name: string;
-  stats: IFileSystemStats;
+  entry: IFsMemStatsEntry;
 }
 
 export type IFsMemNodeType = IFsMemFileNode | IFsMemDirectoryNode | IFsMemSymlinkNode;

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -3,6 +3,7 @@ import type {
   IBaseFileSystemAsync,
   IFileSystemAsync,
   IFileSystemSync,
+  IFileSystemStats,
 } from '@file-services/types';
 
 export interface IMemFileSystem extends IFileSystemSync, IFileSystemAsync {
@@ -20,8 +21,7 @@ export interface IBaseMemFileSystemSync extends IBaseFileSystemSync {
 export interface IFsMemNode {
   type: 'file' | 'dir' | 'symlink';
   name: string;
-  birthtime: Date;
-  mtime: Date;
+  stats: IFileSystemStats;
 }
 
 export type IFsMemNodeType = IFsMemFileNode | IFsMemDirectoryNode | IFsMemSymlinkNode;


### PR DESCRIPTION
creates a stats object per node, and uses that.
only creates new objects when modifying values.