### PR TITLE
test: pass actual temp directory to contract

### DIFF
--- a/packages/node/test/node-fs.spec.ts
+++ b/packages/node/test/node-fs.spec.ts
@@ -17,7 +17,7 @@ describe('Node File System Implementation', () => {
         await watchService.unwatchAllPaths();
         await tempDirectory.remove();
       },
-      tempDirectoryPath: tempDirectory.path,
+      tempDirectoryPath: fs.realpathSync(tempDirectory.path),
     };
   };
 

--- a/packages/test-kit/src/sync-base-fs-contract.ts
+++ b/packages/test-kit/src/sync-base-fs-contract.ts
@@ -742,8 +742,8 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
         fs.symlinkSync(targetPath, linkPath);
         fs.symlinkSync(linkPath, linkToLinkPath);
 
-        expect(fs.realpathSync(linkPath)).to.equal(fs.realpathSync(targetPath));
-        expect(fs.realpathSync(linkToLinkPath)).to.equal(fs.realpathSync(targetPath));
+        expect(fs.realpathSync(linkPath)).to.equal(targetPath);
+        expect(fs.realpathSync(linkToLinkPath)).to.equal(targetPath);
       });
 
       it('keeps relative links relative', () => {


### PR DESCRIPTION
instead of calling realpath on expected result.
ensures nothing funny occurs to the expected value, if realpath is misbehaving.