### PR TITLE
feat(resolve): original path for false-remapped

### DIFF
--- a/packages/resolve/src/request-resolver.ts
+++ b/packages/resolve/src/request-resolver.ts
@@ -1,5 +1,5 @@
 import type { PackageJson } from 'type-fest';
-import type { RequestResolver, IRequestResolverOptions, IResolvedPackageJson } from './types';
+import type { RequestResolver, IRequestResolverOptions, IResolvedPackageJson, IResolutionOutput } from './types';
 
 const defaultTarget = 'browser';
 const defaultPackageRoots = ['node_modules'];
@@ -20,7 +20,7 @@ export function createRequestResolver(options: IRequestResolverOptions): Request
 
   return requestResolver;
 
-  function requestResolver(contextPath: string, originalRequest: string) {
+  function requestResolver(contextPath: string, originalRequest: string): IResolutionOutput {
     let request: string | false = originalRequest;
     if (target === 'browser') {
       const fromPackageJson = findUpPackageJson(contextPath);
@@ -43,6 +43,7 @@ export function createRequestResolver(options: IRequestResolverOptions): Request
         if (remappedFilePath !== undefined) {
           return {
             resolvedFile: remappedFilePath,
+            originalFilePath: resolvedFile,
           };
         }
       }

--- a/packages/resolve/src/types.ts
+++ b/packages/resolve/src/types.ts
@@ -38,6 +38,12 @@ export interface IResolutionOutput {
    * `undefined` - couldn't resolve request.
    */
   resolvedFile?: string | false;
+
+  /**
+   * When an internal package request is re-mapped to `false`, this will point to the original
+   * filePath this request pointed to.
+   */
+  originalFilePath?: string;
 }
 
 /**

--- a/packages/resolve/test/request-resolver.spec.ts
+++ b/packages/resolve/test/request-resolver.spec.ts
@@ -440,6 +440,7 @@ describe('request resolver', () => {
       const resolveRequest = createRequestResolver({ fs });
 
       expect(resolveRequest('/', './some-file')).to.be.resolvedTo(false);
+      expect(resolveRequest('/', './some-file').originalFilePath).to.equal('/some-file.js');
     });
 
     it('supports remapping of package to a relative file', () => {


### PR DESCRIPTION
When an internal package request is re-mapped to `false`, this will point to the original filePath this request pointed to.