### PR TITLE
feat(commonjs): support process.on/cwd

### DIFF
--- a/packages/commonjs/src/base-cjs-module-system.ts
+++ b/packages/commonjs/src/base-cjs-module-system.ts
@@ -3,6 +3,13 @@ import { envGlobal } from './global-this';
 
 export interface IBaseModuleSystemOptions {
   /**
+   * Exposed to modules as `process.cwd`.
+   *
+   * @default () => '/'
+   */
+  cwd?: () => string;
+
+  /**
    * Exposed to modules as `process.env`.
    *
    * @default { NODE_ENV: 'development' }
@@ -32,10 +39,15 @@ export interface IBaseModuleSystemOptions {
 }
 
 export function createBaseCjsModuleSystem(options: IBaseModuleSystemOptions): ICommonJsModuleSystem {
-  const { resolveFrom, dirname, readFileSync, processEnv = { NODE_ENV: 'development' } } = options;
+  const { resolveFrom, dirname, readFileSync, processEnv = { NODE_ENV: 'development' }, cwd = () => '/' } = options;
 
+  const noop = () => undefined;
   const loadedModules = new Map<string, IModule>();
-  const globalProcess = { env: processEnv };
+  const globalProcess = {
+    on: noop,
+    cwd: cwd,
+    env: processEnv,
+  };
 
   return {
     requireModule,

--- a/packages/commonjs/src/cjs-module-system.ts
+++ b/packages/commonjs/src/cjs-module-system.ts
@@ -5,6 +5,13 @@ import { createBaseCjsModuleSystem } from './base-cjs-module-system';
 
 export interface IModuleSystemOptions {
   /**
+   * Exposed to modules as `process.cwd`.
+   *
+   * @default () => '/'
+   */
+  cwd?: () => string;
+
+  /**
    * Exposed to modules as `process.env`.
    *
    * @default { NODE_ENV: 'development' }
@@ -30,7 +37,7 @@ export interface IModuleSystemOptions {
 }
 
 export function createCjsModuleSystem(options: IModuleSystemOptions): ICommonJsModuleSystem {
-  const { fs, processEnv = { NODE_ENV: 'development' } } = options;
+  const { fs, processEnv = { NODE_ENV: 'development' }, cwd } = options;
   const { dirname, readFileSync } = fs;
 
   const { resolver = createRequestResolver({ fs }) } = options;
@@ -40,5 +47,6 @@ export function createCjsModuleSystem(options: IModuleSystemOptions): ICommonJsM
     readFileSync: (filePath) => readFileSync(filePath, 'utf8'),
     dirname,
     processEnv,
+    cwd: cwd ?? fs.cwd,
   });
 }

--- a/packages/commonjs/test/cjs-module-system.spec.ts
+++ b/packages/commonjs/test/cjs-module-system.spec.ts
@@ -96,6 +96,26 @@ describe('commonjs module system', () => {
     expect(requireModule(sampleFilePath)).to.eql(processEnv);
   });
 
+  it('allows specifying a custom process.cwd()', () => {
+    const fs = createMemoryFs({
+      [sampleFilePath]: `module.exports = process.cwd()`,
+    });
+    const cwd = () => '/abc';
+    const { requireModule } = createCjsModuleSystem({ fs, cwd });
+
+    expect(requireModule(sampleFilePath)).to.eql('/abc');
+  });
+
+  it('mocks process.on(...)', () => {
+    const fs = createMemoryFs({
+      [sampleFilePath]: `process.on('uncaughtException', console.error)
+      module.exports = 123`,
+    });
+    const { requireModule } = createCjsModuleSystem({ fs });
+
+    expect(requireModule(sampleFilePath)).to.eql(123);
+  });
+
   it('allows requiring other js modules', () => {
     const fs = createMemoryFs({
       'index.js': `module.exports = require('./numeric')`,

--- a/packages/commonjs/test/npm-packages.nodespec.ts
+++ b/packages/commonjs/test/npm-packages.nodespec.ts
@@ -1,5 +1,9 @@
+import os from 'os';
+import readline from 'readline';
+import stream from 'stream';
 import { expect } from 'chai';
 import fs from '@file-services/node';
+import path from '@file-services/path';
 import { createCjsModuleSystem } from '../src';
 
 describe('commonjs module system - integration with existing npm packages', function () {
@@ -25,6 +29,14 @@ describe('commonjs module system - integration with existing npm packages', func
     expect(chai.use).to.be.instanceOf(Function);
   });
 
+  it('evaluates postcss successfully', () => {
+    const { requireFrom, loadedModules } = createCjsModuleSystem({ fs });
+    loadedModules.set('path', { filename: 'path', id: 'path', exports: path });
+    const postcss = requireFrom(__dirname, 'postcss') as typeof import('postcss');
+
+    expect(postcss.parse).to.be.instanceOf(Function);
+  });
+
   it('evaluates typescript successfully', () => {
     const { requireFrom } = createCjsModuleSystem({ fs });
 
@@ -33,19 +45,22 @@ describe('commonjs module system - integration with existing npm packages', func
     expect(ts.transpileModule).to.be.instanceOf(Function);
   });
 
-  // skipped until external modules (node apis) can be provided using options
-  it.skip('evaluates mocha successfully', () => {
-    const { requireFrom } = createCjsModuleSystem({ fs });
+  it('evaluates mocha successfully', () => {
+    const { requireFrom, loadedModules } = createCjsModuleSystem({ fs });
+    loadedModules.set('path', { filename: 'path', id: 'path', exports: path });
+    loadedModules.set('stream', { filename: 'stream', id: 'stream', exports: stream });
+    const browserMocha = requireFrom(__dirname, 'mocha') as typeof mocha;
 
-    const mocha = requireFrom(__dirname, 'mocha') as typeof import('mocha');
-
-    expect(mocha.setup).to.be.instanceOf(Function);
-    expect(mocha.run).to.be.instanceOf(Function);
+    expect(browserMocha.setup).to.be.instanceOf(Function);
   });
 
-  // skipped until external modules (node apis) can be provided using options
-  it.skip('evaluates sass successfully', () => {
-    const { requireFrom } = createCjsModuleSystem({ fs });
+  it('evaluates sass successfully', () => {
+    const { requireFrom, loadedModules } = createCjsModuleSystem({ fs });
+    loadedModules.set('path', { filename: 'path', id: 'path', exports: path });
+    loadedModules.set('fs', { filename: 'fs', id: 'fs', exports: fs });
+    loadedModules.set('stream', { filename: 'stream', id: 'stream', exports: stream });
+    loadedModules.set('os', { filename: 'os', id: 'os', exports: os });
+    loadedModules.set('readline', { filename: 'readline', id: 'readline', exports: readline });
 
     const sass = requireFrom(__dirname, 'sass') as typeof import('sass');
 


### PR DESCRIPTION
- in higher-order module system factory (one provided with `fs`), it passes `fs.cwd()` for `process.cwd`.
- `process.on` is just a mocked noop.
- enabled several node specs to test this via external libs.