### PR TITLE
infra: migrate to typescript project references

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,2 @@
 node_modules
-cjs
-esm
-umd
 dist

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
     {
       "files": ["*.ts", "*.tsx"],
       "parserOptions": {
-        "project": "./tsconfig.json"
+        "project": "packages/*/{src,test}/tsconfig.json"
       },
       "extends": [
         "plugin:@typescript-eslint/recommended",

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -14,6 +14,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
       - run: npm i -g yarn@1
       - run: yarn --frozen-lockfile
+      - run: yarn build
       - run: npx pleb@3 publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-cjs
-esm
-
 # Logs
 logs
 *.log

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,5 +1,4 @@
 module.exports = {
-  require: ['@ts-tools/node/r', 'tsconfig-paths/register'],
-  extension: ['js', 'json', 'ts', 'tsx'],
   colors: true,
+  spec: './packages/*/dist/test/*.{spec,nodespec}.js',
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,2 @@
-/tsconfig.json
-cjs
-esm
+/tsconfig.base.json
 dist

--- a/package.json
+++ b/package.json
@@ -4,19 +4,16 @@
     "packages/*"
   ],
   "scripts": {
-    "clean": "lerna run clean --stream --parallel",
-    "prebuild": "yarn clean",
-    "build": "lerna run build --stream",
+    "clean": "rimraf ./packages/*/dist",
+    "build": "tsc --build",
+    "watch": "yarn build -w",
     "lint": "eslint . -f codeframe",
-    "pretest": "yarn typecheck && yarn lint",
-    "test": "lerna run test --stream --concurrency=1",
-    "typecheck": "tsc --noEmit",
-    "prettify": "npx prettier \"./**/*.{md,js,ts,tsx}\" --write"
+    "pretest": "yarn build && yarn lint",
+    "test": "yarn test:node && yarn test:browser",
+    "test:node": "mocha --enable-source-maps --parallel",
+    "test:browser": "mocha-pup \"packages/*/dist/**/*.spec.js\""
   },
   "devDependencies": {
-    "@ts-tools/build": "^2.1.1",
-    "@ts-tools/node": "^2.1.1",
-    "@ts-tools/webpack-loader": "^2.1.1",
     "@types/chai": "^4.2.14",
     "@types/chai-as-promised": "^7.1.3",
     "@types/mocha": "^8.0.3",
@@ -39,7 +36,6 @@
     "lerna": "^3.22.1",
     "mocha": "^8.2.0",
     "mocha-pup": "^4.0.4",
-    "npm-run-all": "^4.1.5",
     "promise-assist": "^1.3.0",
     "puppeteer": "^5.3.1",
     "react": "^16.14.0",
@@ -48,8 +44,7 @@
     "sass": "^1.27.0",
     "sinon": "^9.2.0",
     "sinon-chai": "^3.5.0",
-    "tsconfig-paths": "^3.9.0",
-    "tsconfig-paths-webpack-plugin": "^3.3.0",
+    "source-map-loader": "^1.1.1",
     "type-fest": "^0.18.0",
     "typescript": "~4.0.3",
     "webpack": "^4.44.2"

--- a/packages/cached/package.json
+++ b/packages/cached/package.json
@@ -3,7 +3,6 @@
   "description": "A file system wrapper that adds cache to any `IFileSystem` implementation.",
   "version": "4.1.0",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0",
     "@file-services/utils": "^4.1.0"

--- a/packages/cached/package.json
+++ b/packages/cached/package.json
@@ -2,25 +2,17 @@
   "name": "@file-services/cached",
   "description": "A file system wrapper that adds cache to any `IFileSystem` implementation.",
   "version": "4.1.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "esm/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs ./esm",
-    "build": "ts-build ./src --cjs --esm",
-    "test": "run-p test:node test:browser",
-    "test:node": "mocha \"test/**/*.spec.ts?(x)\"",
-    "test:browser": "mocha-pup \"test/**/*.spec.ts?(x)\"",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0",
     "@file-services/utils": "^4.1.0"
   },
   "files": [
-    "cjs",
-    "esm",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/cached",

--- a/packages/cached/src/tsconfig.json
+++ b/packages/cached/src/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [
+    {
+      "path": "../../types/src"
+    },
+    {
+      "path": "../../utils/src"
+    }
+  ]
+}

--- a/packages/cached/test/tsconfig.json
+++ b/packages/cached/test/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../dist/test",
-    "types": ["mocha", "node"]
+    "types": ["mocha"]
   },
   "references": [
     {

--- a/packages/cached/test/tsconfig.json
+++ b/packages/cached/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/test",
+    "types": ["mocha", "node"]
+  },
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../memory/src"
+    },
+    {
+      "path": "../../test-kit/src"
+    }
+  ]
+}

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -3,7 +3,6 @@
   "description": "Isomorphic, fs-agnostic implementation of the Node commonjs module system.",
   "version": "4.2.0",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/resolve": "^4.2.0",
     "@file-services/types": "^4.1.0"

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -2,25 +2,17 @@
   "name": "@file-services/commonjs",
   "description": "Isomorphic, fs-agnostic implementation of the Node commonjs module system.",
   "version": "4.2.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "esm/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs ./esm",
-    "build": "ts-build ./src --cjs --esm",
-    "test": "run-p test:node test:browser",
-    "test:node": "mocha \"test/**/*.{spec,nodespec}.ts?(x)\"",
-    "test:browser": "mocha-pup \"test/**/*.spec.ts?(x)\"",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/resolve": "^4.2.0",
     "@file-services/types": "^4.1.0"
   },
   "files": [
-    "cjs",
-    "esm",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/commonjs",

--- a/packages/commonjs/src/tsconfig.json
+++ b/packages/commonjs/src/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [
+    {
+      "path": "../../resolve/src"
+    },
+    {
+      "path": "../../types/src"
+    }
+  ]
+}

--- a/packages/commonjs/test/tsconfig.json
+++ b/packages/commonjs/test/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../dist/test",
-    "types": ["mocha", "node"]
+    "types": ["mocha"]
   },
   "references": [
     {

--- a/packages/commonjs/test/tsconfig.json
+++ b/packages/commonjs/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/test",
+    "types": ["mocha", "node"]
+  },
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../memory/src"
+    },
+    {
+      "path": "../../node/src"
+    }
+  ]
+}

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -2,26 +2,18 @@
   "name": "@file-services/directory",
   "description": "A file system wrapper that adds directory scoping to any `IFileSystem` implementation.",
   "version": "4.1.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "esm/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs ./esm",
-    "build": "ts-build ./src --cjs --esm",
-    "test": "run-p test:node test:browser",
-    "test:node": "mocha \"test/**/*.{spec,nodespec}.ts?(x)\"",
-    "test:browser": "mocha-pup \"test/**/*.spec.ts?(x)\"",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/path": "^4.1.0",
     "@file-services/types": "^4.1.0",
     "@file-services/utils": "^4.1.0"
   },
   "files": [
-    "cjs",
-    "esm",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/directory",

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -3,7 +3,6 @@
   "description": "A file system wrapper that adds directory scoping to any `IFileSystem` implementation.",
   "version": "4.1.0",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/path": "^4.1.0",
     "@file-services/types": "^4.1.0",

--- a/packages/directory/src/tsconfig.json
+++ b/packages/directory/src/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [
+    {
+      "path": "../../types/src"
+    },
+    {
+      "path": "../../utils/src"
+    }
+  ]
+}

--- a/packages/directory/test/tsconfig.json
+++ b/packages/directory/test/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/test",
+    "types": ["mocha", "node"]
+  },
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../memory/src"
+    },
+    {
+      "path": "../../node/src"
+    },
+    {
+      "path": "../../test-kit/src"
+    }
+  ]
+}

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -3,7 +3,6 @@
   "description": "An in-memory, sync/async, file system implementation.",
   "version": "4.1.2",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/path": "^4.1.0",
     "@file-services/types": "^4.1.0",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -2,26 +2,18 @@
   "name": "@file-services/memory",
   "description": "An in-memory, sync/async, file system implementation.",
   "version": "4.1.2",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "esm/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs ./esm",
-    "build": "ts-build ./src --cjs --esm",
-    "test": "run-p test:node test:browser",
-    "test:node": "mocha \"test/**/*.spec.ts?(x)\"",
-    "test:browser": "mocha-pup \"test/**/*.spec.ts?(x)\"",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/path": "^4.1.0",
     "@file-services/types": "^4.1.0",
     "@file-services/utils": "^4.1.0"
   },
   "files": [
-    "cjs",
-    "esm",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/memory",

--- a/packages/memory/src/tsconfig.json
+++ b/packages/memory/src/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [
+    {
+      "path": "../../types/src"
+    },
+    {
+      "path": "../../utils/src"
+    }
+  ]
+}

--- a/packages/memory/test/tsconfig.json
+++ b/packages/memory/test/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../dist/test",
-    "types": ["mocha", "node"]
+    "types": ["mocha"]
   },
   "references": [
     {

--- a/packages/memory/test/tsconfig.json
+++ b/packages/memory/test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/test",
+    "types": ["mocha", "node"]
+  },
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../test-kit/src"
+    }
+  ]
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -3,7 +3,6 @@
   "description": "Node.js file system implementation.",
   "version": "4.1.2",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0",
     "@file-services/utils": "^4.1.0"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,21 +2,17 @@
   "name": "@file-services/node",
   "description": "Node.js file system implementation.",
   "version": "4.1.2",
-  "main": "cjs/index.js",
-  "types": "cjs/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs",
-    "build": "ts-build ./src --cjs",
-    "test": "mocha \"test/**/*.nodespec.ts?(x)\"",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0",
     "@file-services/utils": "^4.1.0"
   },
   "files": [
-    "cjs",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "engines": {
     "node": ">=10.12.0"

--- a/packages/node/src/tsconfig.json
+++ b/packages/node/src/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist",
+    "types": ["node"]
+  },
+  "references": [
+    {
+      "path": "../../types/src"
+    },
+    {
+      "path": "../../utils/src"
+    }
+  ]
+}

--- a/packages/node/test/tsconfig.json
+++ b/packages/node/test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/test",
+    "types": ["mocha", "node"]
+  },
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../test-kit/src"
+    }
+  ]
+}

--- a/packages/node/test/watch-service.nodespec.ts
+++ b/packages/node/test/watch-service.nodespec.ts
@@ -10,7 +10,7 @@ const debounceWait = 500;
 const SAMPLE_CONTENT = `sample file content`;
 
 describe('Node Watch Service', function () {
-  this.timeout(10000); // override mocha's 2s timeout to 10s
+  this.timeout(10_000);
 
   let tempDir: ITempDirectory;
   let watchService: IWatchService;

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -3,7 +3,6 @@
   "description": "Overlay files and directories from one file system on top of another.",
   "version": "4.1.0",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0",
     "@file-services/utils": "^4.1.0"

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -2,25 +2,17 @@
   "name": "@file-services/overlay",
   "description": "Overlay files and directories from one file system on top of another.",
   "version": "4.1.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "esm/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs ./esm",
-    "build": "ts-build ./src --cjs --esm",
-    "test": "run-p test:node test:browser",
-    "test:node": "mocha \"test/**/*.spec.ts?(x)\"",
-    "test:browser": "mocha-pup \"test/**/*.spec.ts?(x)\"",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0",
     "@file-services/utils": "^4.1.0"
   },
   "files": [
-    "cjs",
-    "esm",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/overlay",

--- a/packages/overlay/src/globals.d.ts
+++ b/packages/overlay/src/globals.d.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line no-var
+declare var Error: ErrorConstructor;
+
+// to avoid having to include @types/node just for this optional field
+interface ErrorConstructor {
+  stackTraceLimit?: number;
+}

--- a/packages/overlay/src/tsconfig.json
+++ b/packages/overlay/src/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [
+    {
+      "path": "../../types/src"
+    },
+    {
+      "path": "../../utils/src"
+    }
+  ]
+}

--- a/packages/overlay/test/tsconfig.json
+++ b/packages/overlay/test/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../dist/test",
-    "types": ["mocha", "node"]
+    "types": ["mocha"]
   },
   "references": [
     {

--- a/packages/overlay/test/tsconfig.json
+++ b/packages/overlay/test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/test",
+    "types": ["mocha", "node"]
+  },
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../test-kit/src"
+    }
+  ]
+}

--- a/packages/path/package.json
+++ b/packages/path/package.json
@@ -3,7 +3,6 @@
   "description": "Node's `path` implementation, ready for the web.",
   "version": "4.1.0",
   "main": "index.js",
-  "types": "index.d.ts",
   "browser": "browser-path.js",
   "dependencies": {
     "@file-services/types": "^4.1.0"

--- a/packages/resolve/package.json
+++ b/packages/resolve/package.json
@@ -2,21 +2,13 @@
   "name": "@file-services/resolve",
   "description": "Isomorphic, fs-agnostic implementation of the Node resolution algorithm.",
   "version": "4.2.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "esm/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs ./esm",
-    "build": "ts-build ./src --cjs --esm",
-    "test": "run-p test:node test:browser",
-    "test:node": "mocha \"test/**/*.{spec,nodespec}.ts?(x)\"",
-    "test:browser": "mocha-pup \"test/**/*.spec.ts?(x)\"",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "cjs",
-    "esm",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/resolve",

--- a/packages/resolve/package.json
+++ b/packages/resolve/package.json
@@ -3,7 +3,6 @@
   "description": "Isomorphic, fs-agnostic implementation of the Node resolution algorithm.",
   "version": "4.2.0",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "!dist/test",

--- a/packages/resolve/src/globals.d.ts
+++ b/packages/resolve/src/globals.d.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line no-var
+declare var Error: ErrorConstructor;
+
+// to avoid having to include @types/node just for this optional field
+interface ErrorConstructor {
+  stackTraceLimit?: number;
+}

--- a/packages/resolve/src/tsconfig.json
+++ b/packages/resolve/src/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [
+    {
+      "path": "../../types/src"
+    }
+  ]
+}

--- a/packages/resolve/test/tsconfig.json
+++ b/packages/resolve/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/test",
+    "types": ["mocha", "node"]
+  },
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../memory/src"
+    },
+    {
+      "path": "../../node/src"
+    }
+  ]
+}

--- a/packages/test-kit/package.json
+++ b/packages/test-kit/package.json
@@ -3,7 +3,6 @@
   "description": "File system test-kit, containing contracts and validators.",
   "version": "4.1.2",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0",
     "chai": "^4.2.0",

--- a/packages/test-kit/package.json
+++ b/packages/test-kit/package.json
@@ -2,23 +2,18 @@
   "name": "@file-services/test-kit",
   "description": "File system test-kit, containing contracts and validators.",
   "version": "4.1.2",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "esm/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs ./esm",
-    "build": "ts-build ./src --cjs --esm",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0",
     "chai": "^4.2.0",
     "promise-assist": "^1.3.0"
   },
   "files": [
-    "cjs",
-    "esm",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/test-kit",

--- a/packages/test-kit/src/tsconfig.json
+++ b/packages/test-kit/src/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist",
+    "types": ["mocha", "node"]
+  },
+  "references": [
+    {
+      "path": "../../types/src"
+    }
+  ]
+}

--- a/packages/test-kit/src/tsconfig.json
+++ b/packages/test-kit/src/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../dist",
-    "types": ["mocha", "node"]
+    "types": ["mocha"]
   },
   "references": [
     {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,16 +2,13 @@
   "name": "@file-services/types",
   "description": "Common file system interfaces",
   "version": "4.1.0",
-  "main": "cjs/index.js",
-  "types": "cjs/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs",
-    "build": "ts-build ./src --cjs",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "cjs",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/types",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,7 +3,6 @@
   "description": "Common file system interfaces",
   "version": "4.1.0",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "!dist/test",

--- a/packages/types/src/tsconfig.json
+++ b/packages/types/src/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  }
+}

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -2,14 +2,8 @@
   "name": "@file-services/typescript",
   "description": "Helpers for creation of TypeScript hosts",
   "version": "4.1.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "esm/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs ./esm",
-    "build": "ts-build ./src --cjs --esm",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "peerDependencies": {
     "typescript": ">=2.8.0"
   },
@@ -17,9 +11,10 @@
     "@file-services/types": "^4.1.0"
   },
   "files": [
-    "cjs",
-    "esm",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/typescript",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -3,7 +3,6 @@
   "description": "Helpers for creation of TypeScript hosts",
   "version": "4.1.0",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "peerDependencies": {
     "typescript": ">=2.8.0"
   },

--- a/packages/typescript/src/globals.d.ts
+++ b/packages/typescript/src/globals.d.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line no-var
+declare var Error: ErrorConstructor;
+
+// to avoid having to include @types/node just for this optional field
+interface ErrorConstructor {
+  stackTraceLimit?: number;
+}

--- a/packages/typescript/src/tsconfig.json
+++ b/packages/typescript/src/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [
+    {
+      "path": "../../types/src"
+    }
+  ]
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,21 +2,16 @@
   "name": "@file-services/utils",
   "description": "Common file system utility functions.",
   "version": "4.1.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "esm/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs ./esm",
-    "build": "ts-build ./src --cjs --esm",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0"
   },
   "files": [
-    "cjs",
-    "esm",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/utils",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,7 +3,6 @@
   "description": "Common file system utility functions.",
   "version": "4.1.0",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0"
   },

--- a/packages/utils/src/create-extended-api.ts
+++ b/packages/utils/src/create-extended-api.ts
@@ -81,7 +81,7 @@ export function createExtendedSyncActions(baseFs: IBaseFileSystemSync): IFileSys
     try {
       mkdirSync(directoryPath);
     } catch (e) {
-      const code = (e as NodeJS.ErrnoException)?.code;
+      const code = (e as { code?: string })?.code;
       if (code === 'EISDIR') {
         return;
       } else if (code === 'EEXIST') {
@@ -103,7 +103,7 @@ export function createExtendedSyncActions(baseFs: IBaseFileSystemSync): IFileSys
       try {
         mkdirSync(directoryPath);
       } catch (e) {
-        const code = (e as NodeJS.ErrnoException)?.code;
+        const code = (e as { code?: string })?.code;
         const isDirectoryExistsError = code === 'EISDIR' || (code === 'EEXIST' && directoryExistsSync(directoryPath));
         if (!isDirectoryExistsError) {
           throw e;
@@ -274,7 +274,7 @@ export function createExtendedFileSystemPromiseActions(
     try {
       await mkdir(directoryPath);
     } catch (e) {
-      const code = (e as NodeJS.ErrnoException)?.code;
+      const code = (e as { code?: string })?.code;
       if (code === 'EISDIR') {
         return;
       } else if (code === 'EEXIST') {
@@ -296,7 +296,7 @@ export function createExtendedFileSystemPromiseActions(
       try {
         await mkdir(directoryPath);
       } catch (e) {
-        const code = (e as NodeJS.ErrnoException)?.code;
+        const code = (e as { code?: string })?.code;
         const isDirectoryExistsError =
           code === 'EISDIR' || (code === 'EEXIST' && (await directoryExists(directoryPath)));
         if (!isDirectoryExistsError) {

--- a/packages/utils/src/globals.d.ts
+++ b/packages/utils/src/globals.d.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line no-var
+declare var Error: ErrorConstructor;
+
+// to avoid having to include @types/node just for this optional field
+interface ErrorConstructor {
+  stackTraceLimit?: number;
+}

--- a/packages/utils/src/tsconfig.json
+++ b/packages/utils/src/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [
+    {
+      "path": "../../types/src"
+    }
+  ]
+}

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -2,23 +2,16 @@
   "name": "@file-services/webpack",
   "description": "Helpers for creation of webpack-compatible file systems.",
   "version": "4.1.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "esm/index.d.ts",
-  "scripts": {
-    "clean": "rimraf ./cjs ./esm",
-    "build": "ts-build ./src --cjs --esm",
-    "test": "yarn test:node",
-    "test:node": "mocha \"test/**/*.nodespec.ts?(x)\"",
-    "prepack": "yarn build"
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0"
   },
   "files": [
-    "cjs",
-    "esm",
-    "src"
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "license": "MIT",
   "repository": "https://github.com/wixplosives/file-services/tree/master/packages/webpack",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -3,7 +3,6 @@
   "description": "Helpers for creation of webpack-compatible file systems.",
   "version": "4.1.0",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "dependencies": {
     "@file-services/types": "^4.1.0"
   },

--- a/packages/webpack/src/tsconfig.json
+++ b/packages/webpack/src/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [
+    {
+      "path": "../../types/src"
+    }
+  ]
+}

--- a/packages/webpack/test/fixture/some-file.js
+++ b/packages/webpack/test/fixture/some-file.js
@@ -1,1 +1,0 @@
-module.exports = 'Hello';

--- a/packages/webpack/test/fixture/some-file.ts
+++ b/packages/webpack/test/fixture/some-file.ts
@@ -1,0 +1,1 @@
+export default 'Hello';

--- a/packages/webpack/test/tsconfig.json
+++ b/packages/webpack/test/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/test",
+    "types": ["mocha", "node"]
+  },
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../node/src"
+    },
+    {
+      "path": "../../memory/src"
+    },
+    {
+      "path": "../../overlay/src"
+    },
+    {
+      "path": "../../webpack/src"
+    }
+  ]
+}

--- a/packages/webpack/test/tsconfig.json
+++ b/packages/webpack/test/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../dist/test",
-    "types": ["mocha", "node"]
+    "types": ["mocha"]
   },
   "references": [
     {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,70 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "lib": ["es2019"],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    "noUnusedLocals": true,                /* Report errors on unused locals. */
+    "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    "importsNotUsedAsValues": "error",
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,68 +1,37 @@
 {
-  "compilerOptions": {
-    /* Basic Options */
-    "target": "es2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "esnext",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": [
-      "esnext"
-    ],                                        /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
-    "declarationMap": true,                   /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true,                        /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "references": [
+    { "path": "./packages/cached/src" },
+    { "path": "./packages/cached/test" },
 
-    /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+    { "path": "./packages/commonjs/src" },
+    { "path": "./packages/commonjs/test" },
 
-    /* Additional Checks */
-    "noUnusedLocals": true,                   /* Report errors on unused locals. */
-    "noUnusedParameters": true,               /* Report errors on unused parameters. */
-    "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
-    "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
-    "importsNotUsedAsValues": "error",
+    { "path": "./packages/directory/src" },
+    { "path": "./packages/directory/test" },
 
-    /* Module Resolution Options */
-    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
-    "paths": {
-      "@file-services/*": [
-        "packages/*/src"
-      ]
-    },                                        /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    "forceConsistentCasingInFileNames": true, /* Forces imports with correct casing, so they work on case-sensitive OSs. */
-    "newLine": "LF"                           /* Ensures files containing shebang (e.g. cli entry) work on any terminal. */
+    { "path": "./packages/memory/src" },
+    { "path": "./packages/memory/test" },
 
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    { "path": "./packages/node/src" },
+    { "path": "./packages/node/test" },
 
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-  }
+    { "path": "./packages/overlay/src" },
+    { "path": "./packages/overlay/test" },
+
+    { "path": "./packages/resolve/src" },
+    { "path": "./packages/resolve/test" },
+
+    { "path": "./packages/test-kit/src" },
+
+    { "path": "./packages/types/src" },
+
+    { "path": "./packages/typescript/src" },
+
+    { "path": "./packages/utils/src" },
+
+    { "path": "./packages/webpack/src" },
+    { "path": "./packages/webpack/test" }
+  ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,23 +1,13 @@
-const { join } = require('path');
-const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
-
+/** @type {import('webpack').Configuration} */
 module.exports = {
-  // root of the monorepo, so that paths in output will be clickable
-  context: __dirname,
-
-  // works great. with the default 'eval', imports are not mapped.
-  devtool: 'source-map',
-
-  resolve: {
-    extensions: ['.ts', '.tsx', '.mjs', '.js', '.json'],
-    plugins: [new TsconfigPathsPlugin({ configFile: join(__dirname, 'tsconfig.json') })],
-  },
-
+  context: __dirname, // so paths in output will be clickable
+  devtool: 'source-map', // works great (unlike default "eval", where imports are not mapped)
   module: {
     rules: [
       {
-        test: /\.tsx?$/,
-        loader: '@ts-tools/webpack-loader',
+        test: /\.js$/,
+        enforce: 'pre',
+        loader: 'source-map-loader',
       },
     ],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,36 +977,6 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@ts-tools/build@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@ts-tools/build/-/build-2.1.1.tgz#6580c0ed5aea8ee8de93d43f40929fcba211f3a5"
-  integrity sha512-uuyXyYMa5BBbZoOddoBQPd+keLUjBR+V7unYAv/cjkCKwahbCAHTlvm2EIXIVafFyMJ9Egit4D9kohE3Q8j8fw==
-  dependencies:
-    "@ts-tools/transpile" "^2.1.1"
-    chalk "^4.1.0"
-    commander "^6.1.0"
-
-"@ts-tools/node@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@ts-tools/node/-/node-2.1.1.tgz#2923b4386e543bd20d534824429440b46ac87e95"
-  integrity sha512-+pcRdNZIz32c8lxZrKJAoXxD/X9UgdioV7ccqfXL0h1Yyt+VeGdSUknxJ3WyKWiDKiS4RacL4LqHztaSUmBiLA==
-  dependencies:
-    "@ts-tools/transpile" "^2.1.1"
-    source-map-support "^0.5.19"
-
-"@ts-tools/transpile@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@ts-tools/transpile/-/transpile-2.1.1.tgz#f2448013cdfc2944055d0446a568da97b93c6a3e"
-  integrity sha512-kuhuOlvexcF2UBkmnr+Ir8yhInzJtItiuUxLEgYKQ6odVsD1w7N1n9B0Eqxj9ZT53rhYWUzZEzMWalh9l34EPQ==
-
-"@ts-tools/webpack-loader@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@ts-tools/webpack-loader/-/webpack-loader-2.1.1.tgz#29971073f4650935f075e747883b8f9342cec340"
-  integrity sha512-lHYxSZCajnPcaODE0VKYizsq6qmrd8UAESJfNWfQHKZVvIScH64HRdLfBRKQXYSfmELa/6Lg6s0fqg6KJlfieA==
-  dependencies:
-    "@ts-tools/transpile" "^2.1.1"
-    loader-utils "^2.0.0"
-
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -1041,11 +1011,6 @@
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
-
-"@types/json5@^0.0.29":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
-  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -1423,6 +1388,11 @@ JSONStream@^1.0.4, JSONStream@^1.3.4:
   dependencies:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
+
+abab@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
+  integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
 abbrev@1:
   version "1.1.1"
@@ -2144,7 +2114,7 @@ chai@^4.2.0:
     pathval "^1.1.0"
     type-detect "^4.0.5"
 
-chalk@^2.0.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.3.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2600,7 +2570,7 @@ create-temp-directory@^1.1.1:
   dependencies:
     rimraf "^3.0.0"
 
-cross-spawn@^6.0.0, cross-spawn@^6.0.5:
+cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -3051,7 +3021,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^4.0.0, enhanced-resolve@^4.3.0:
+enhanced-resolve@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
   integrity sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==
@@ -5057,11 +5027,6 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-memorystream@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
-  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
-
 meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -5618,21 +5583,6 @@ npm-pick-manifest@^3.0.0:
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
 
-npm-run-all@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
-  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    chalk "^2.4.1"
-    cross-spawn "^6.0.5"
-    memorystream "^0.3.1"
-    minimatch "^3.0.4"
-    pidtree "^0.3.0"
-    read-pkg "^3.0.0"
-    shell-quote "^1.6.1"
-    string.prototype.padend "^3.0.0"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -6108,11 +6058,6 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
-
-pidtree@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
-  integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -7000,11 +6945,6 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.6.1:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
-  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
-
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
@@ -7115,6 +7055,18 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
+source-map-loader@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-1.1.1.tgz#1dd964294cfcc3d9bab65f46af97a38d8ae0c65d"
+  integrity sha512-m2HjSWP2R1yR9P31e4+ciGHFOPvW6GmqHgZkneOkrME2VvWysXTGi4o0yS28iKWWP3vAUmAoa+3x5ZRI2BIX6A==
+  dependencies:
+    abab "^2.0.5"
+    iconv-lite "^0.6.2"
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+    source-map "^0.6.1"
+    whatwg-mimetype "^2.3.0"
+
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -7126,7 +7078,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.19, source-map-support@~0.5.12:
+source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -7298,14 +7250,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string.prototype.padend@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz#dc08f57a8010dc5c153550318f67e13adbb72ac3"
-  integrity sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
 
 string.prototype.trimend@^1.0.1:
   version "1.0.1"
@@ -7662,25 +7606,6 @@ trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
-
-tsconfig-paths-webpack-plugin@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.3.0.tgz#a7461723c20623ca9148621a5ce36532682ad2ff"
-  integrity sha512-MpQeZpwPY4gYASCUjY4yt2Zj8yv86O8f++3Ai4o0yI0fUC6G1syvnL9VuY71PBgimRYDQU47f12BEmJq9wRaSw==
-  dependencies:
-    chalk "^2.3.0"
-    enhanced-resolve "^4.0.0"
-    tsconfig-paths "^3.4.0"
-
-tsconfig-paths@^3.4.0, tsconfig-paths@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
-  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
-  dependencies:
-    "@types/json5" "^0.0.29"
-    json5 "^1.0.1"
-    minimist "^1.2.0"
-    strip-bom "^3.0.0"
 
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
@@ -8051,6 +7976,11 @@ webpack@^4.44.2:
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
+
+whatwg-mimetype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
- build is super-fast now (<4s for entire repo on fresh clone; <0.5s on 2nd+ runs).
- all packages output into a ./dist folder.
- type separation between "src" and "test".
- test files no longer care about output structure.
- node tests now run in --parallel mode, and finish much faster.