### PR TITLE
breaking(commonjs): support injecting globals

### DIFF
--- a/packages/commonjs/src/cjs-module-system.ts
+++ b/packages/commonjs/src/cjs-module-system.ts
@@ -5,18 +5,9 @@ import { createBaseCjsModuleSystem } from './base-cjs-module-system';
 
 export interface IModuleSystemOptions {
   /**
-   * Exposed to modules as `process.cwd`.
-   *
-   * @default () => '/'
+   * Exposed to modules as globals.
    */
-  cwd?: () => string;
-
-  /**
-   * Exposed to modules as `process.env`.
-   *
-   * @default { NODE_ENV: 'development' }
-   */
-  processEnv?: Record<string, string | undefined>;
+  globals?: Record<string, unknown>;
 
   /**
    * Sync file system to use when reading files
@@ -37,7 +28,7 @@ export interface IModuleSystemOptions {
 }
 
 export function createCjsModuleSystem(options: IModuleSystemOptions): ICommonJsModuleSystem {
-  const { fs, processEnv = { NODE_ENV: 'development' }, cwd } = options;
+  const { fs, globals } = options;
   const { dirname, readFileSync } = fs;
 
   const { resolver = createRequestResolver({ fs }) } = options;
@@ -46,7 +37,6 @@ export function createCjsModuleSystem(options: IModuleSystemOptions): ICommonJsM
     resolveFrom: (contextPath, request, requestOrigin) => resolver(contextPath, request, requestOrigin).resolvedFile,
     readFileSync: (filePath) => readFileSync(filePath, 'utf8'),
     dirname,
-    processEnv,
-    cwd: cwd ?? fs.cwd,
+    globals,
   });
 }

--- a/packages/commonjs/src/types.ts
+++ b/packages/commonjs/src/types.ts
@@ -41,15 +41,3 @@ export interface IModule {
    */
   exports: unknown;
 }
-
-export type ModuleEvalFn = (
-  module: IModule,
-  exports: unknown,
-  __filename: string,
-  __dirname: string,
-  process: {
-    env: Record<string, string | undefined>;
-  },
-  require: (request: string) => unknown,
-  global: unknown
-) => void;

--- a/packages/commonjs/test/cjs-module-system.spec.ts
+++ b/packages/commonjs/test/cjs-module-system.spec.ts
@@ -73,45 +73,11 @@ describe('commonjs module system', () => {
     expect(requireModule(sampleFilePath)).to.eql(fs.dirname(sampleFilePath));
   });
 
-  it('exposes process.env with NODE_ENV === "development"', () => {
+  it('injects provided globals', () => {
     const fs = createMemoryFs({
-      [sampleFilePath]: `module.exports = process.env.NODE_ENV`,
+      [sampleFilePath]: `module.exports = injectedValue`,
     });
-    const { requireModule } = createCjsModuleSystem({ fs });
-
-    expect(requireModule(sampleFilePath)).to.eql('development');
-  });
-
-  it('allows specifying a custom process.env record', () => {
-    const fs = createMemoryFs({
-      [sampleFilePath]: `module.exports = {...process.env }`,
-    });
-    const processEnv = {
-      NODE_ENV: 'production',
-      ENV_FLAG: 'some-value',
-    };
-
-    const { requireModule } = createCjsModuleSystem({ fs, processEnv });
-
-    expect(requireModule(sampleFilePath)).to.eql(processEnv);
-  });
-
-  it('allows specifying a custom process.cwd()', () => {
-    const fs = createMemoryFs({
-      [sampleFilePath]: `module.exports = process.cwd()`,
-    });
-    const cwd = () => '/abc';
-    const { requireModule } = createCjsModuleSystem({ fs, cwd });
-
-    expect(requireModule(sampleFilePath)).to.eql('/abc');
-  });
-
-  it('mocks process.on(...)', () => {
-    const fs = createMemoryFs({
-      [sampleFilePath]: `process.on('uncaughtException', console.error)
-      module.exports = 123`,
-    });
-    const { requireModule } = createCjsModuleSystem({ fs });
+    const { requireModule } = createCjsModuleSystem({ fs, globals: { injectedValue: 123 } });
 
     expect(requireModule(sampleFilePath)).to.eql(123);
   });

--- a/packages/webpack/test/webpack-fs.nodespec.ts
+++ b/packages/webpack/test/webpack-fs.nodespec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import webpack from 'webpack';
-import { nodeFs } from '@file-services/node';
+import nodeFs from '@file-services/node';
 import { createMemoryFs } from '@file-services/memory';
 import { createOverlayFs } from '@file-services/overlay';
 import { createWebpackFs } from '@file-services/webpack';


### PR DESCRIPTION
- drop processEnv and cwd options. one can simply inject process.
- re-enable sass test. no longer causes webpack to break.