### PR TITLE
fix(resolve): handle recursive imports to index.js

### DIFF
--- a/packages/resolve/src/request-resolver.ts
+++ b/packages/resolve/src/request-resolver.ts
@@ -4,7 +4,8 @@ import type { RequestResolver, IRequestResolverOptions, IResolvedPackageJson, IR
 const defaultTarget = 'browser';
 const defaultPackageRoots = ['node_modules'];
 const defaultExtensions = ['.js', '.json'];
-const isRelative = (request: string) => request.startsWith('./') || request.startsWith('../');
+const isRelative = (request: string) =>
+  request === '.' || request === '..' || request.startsWith('./') || request.startsWith('../');
 const PACKAGE_JSON = 'package.json';
 
 export function createRequestResolver(options: IRequestResolverOptions): RequestResolver {

--- a/packages/resolve/test/request-resolver.spec.ts
+++ b/packages/resolve/test/request-resolver.spec.ts
@@ -133,6 +133,8 @@ describe('request resolver', () => {
       expect(resolveRequest('/', './src')).to.be.resolvedTo('/src/index.js');
       expect(resolveRequest('/', './data')).to.be.resolvedTo('/data/index.json');
       expect(resolveRequest('/', './typed')).to.be.resolvedTo('/typed/index.ts');
+      expect(resolveRequest('/src', '.')).to.be.resolvedTo('/src/index.js');
+      expect(resolveRequest('/src/inside', '..')).to.be.resolvedTo('/src/index.js');
     });
 
     it('resolves requests to a folder if it contains a package.json with a main', () => {


### PR DESCRIPTION
`"."` and `".."` didn't work.
`"./"` and `"../"` did. :)