### PR TITLE
feat(commonjs): retain file path in module eval

### DIFF
--- a/packages/commonjs/src/base-cjs-module-system.ts
+++ b/packages/commonjs/src/base-cjs-module-system.ts
@@ -89,9 +89,9 @@ export function createBaseCjsModuleSystem(options: IBaseModuleSystemOptions): IC
       global: envGlobal,
       ...globals,
     };
-    const moduleFn = eval(`(function (${Object.keys(moduleArguments).join(', ')}){${fileContents}\n})`) as (
-      ...args: unknown[]
-    ) => void;
+    const moduleFn = eval(
+      `(function (${Object.keys(moduleArguments).join(', ')}){${fileContents}\n//# sourceURL=${filePath}\n})`
+    ) as (...args: unknown[]) => void;
 
     loadedModules.set(filePath, newModule);
 

--- a/packages/commonjs/test/cjs-module-system.spec.ts
+++ b/packages/commonjs/test/cjs-module-system.spec.ts
@@ -210,7 +210,17 @@ describe('commonjs module system', () => {
     });
     const { requireModule } = createCjsModuleSystem({ fs });
 
-    expect(() => requireModule(sampleFilePath)).to.throw(`Thanos is coming!`);
+    let caughtError: unknown = undefined;
+    expect(() => {
+      try {
+        requireModule(sampleFilePath);
+      } catch (e) {
+        caughtError = e;
+        throw e;
+      }
+    }).to.throw(`Thanos is coming!`);
+
+    expect((caughtError as Error)?.stack).to.include(sampleFilePath);
   });
 
   it('does not cache module if code parsing failed', () => {


### PR DESCRIPTION
pretty naive way of retaining file paths during evaluation.

works in node and chrome (probably ff too).

proper source-map support still requires investigation.