### PR TITLE
feat: throwIfNoEntry in stat/statSync

### DIFF
--- a/packages/cached/src/cached-fs.ts
+++ b/packages/cached/src/cached-fs.ts
@@ -28,13 +28,18 @@ interface IFailureCacheResult {
 
 export function createCachedFs(fs: IFileSystem): ICachedFileSystem {
   const getCanonicalPath = fs.caseSensitive ? identity : toLowerCase;
-  const statsCache = new Map<string, ISuccessCacheResult<IFileSystemStats> | IFailureCacheResult>();
+  const statsCache = new Map<string, ISuccessCacheResult<IFileSystemStats | undefined> | IFailureCacheResult>();
   const realpathCache = new Map<string, string>();
-  const { promises } = fs;
+  const { promises, delimiter } = fs;
+
+  const suffixTrue = delimiter + 'true';
+  const suffixFalse = delimiter + 'false';
+
   const invalidateAbsolute = (absolutePath: string) => {
     const cachePath = getCanonicalPath(absolutePath);
     realpathCache.delete(cachePath);
-    statsCache.delete(cachePath);
+    statsCache.delete(cachePath + suffixTrue);
+    statsCache.delete(cachePath + suffixFalse);
   };
   const invalidateAbsoluteByPrefix = (absolutePath: string) => {
     const prefix = getCanonicalPath(absolutePath);
@@ -126,20 +131,21 @@ export function createCachedFs(fs: IFileSystem): ICachedFileSystem {
         }
         return fs.writeFileSync(filePath, ...args);
       },
-      statSync(path) {
+      statSync(path, options) {
         path = fs.resolve(path);
-        const cacheKey = getCanonicalPath(path);
+        const throwIfNoEntry = options?.throwIfNoEntry ?? true;
+        const cacheKey = getCanonicalPath(path) + (throwIfNoEntry ? suffixTrue : suffixFalse);
         const cachedStats = statsCache.get(cacheKey);
         if (cachedStats) {
           if (cachedStats.kind === 'failure') {
             throw cachedStats.error;
           }
-          return cachedStats.value;
+          return cachedStats.value as IFileSystemStats;
         }
         try {
-          const stats = fs.statSync(path);
+          const stats = fs.statSync(path, options);
           statsCache.set(cacheKey, { kind: 'success', value: stats });
-          return stats;
+          return stats as IFileSystemStats;
         } catch (e) {
           statsCache.set(cacheKey, { kind: 'failure', error: e as Error });
           throw e;
@@ -147,13 +153,15 @@ export function createCachedFs(fs: IFileSystem): ICachedFileSystem {
       },
       stat(path, callback) {
         path = fs.resolve(path);
-        const cacheKey = getCanonicalPath(path);
+        // callback version has own error handling mechanism, so always true suffix
+        const cacheKey = getCanonicalPath(path) + suffixTrue;
         const cachedStats = statsCache.get(cacheKey);
         if (cachedStats) {
           if (cachedStats.kind === 'failure') {
             (callback as (e: Error) => void)(cachedStats.error);
           } else if (cachedStats.kind === 'success') {
-            callback(null, cachedStats.value);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            callback(null, cachedStats.value!);
           }
         } else {
           fs.stat(path, (error, stats) => {
@@ -251,20 +259,21 @@ export function createCachedFs(fs: IFileSystem): ICachedFileSystem {
         }
         return promises.writeFile(filePath, ...args);
       },
-      async stat(path: string) {
+      async stat(path, options) {
         path = fs.resolve(path);
-        const cacheKey = getCanonicalPath(path);
+        const throwIfNoEntry = options?.throwIfNoEntry ?? true;
+        const cacheKey = getCanonicalPath(path) + (throwIfNoEntry ? suffixTrue : suffixFalse);
         const cachedStats = statsCache.get(cacheKey);
         if (cachedStats) {
           if (cachedStats.kind === 'failure') {
             throw cachedStats.error;
           }
-          return cachedStats.value;
+          return cachedStats.value as IFileSystemStats;
         }
         try {
-          const stats = await promises.stat(path);
+          const stats = await promises.stat(path, options);
           statsCache.set(cacheKey, { kind: 'success', value: stats });
-          return stats;
+          return stats as IFileSystemStats;
         } catch (e) {
           statsCache.set(cacheKey, { kind: 'failure', error: e as Error });
           throw e;

--- a/packages/directory/src/directory-fs.ts
+++ b/packages/directory/src/directory-fs.ts
@@ -106,9 +106,6 @@ export function createDirectoryFs(fs: IFileSystem, directoryPath: string): IFile
       copyFile(srcPath, destPath, ...args) {
         return fsPromises.copyFile(resolveFullPath(srcPath), resolveFullPath(destPath), ...args);
       },
-      lstat(path) {
-        return fsPromises.lstat(resolveFullPath(path));
-      },
       mkdir(path, ...args) {
         return fsPromises.mkdir(resolveFullPath(path), ...args);
       },
@@ -139,9 +136,12 @@ export function createDirectoryFs(fs: IFileSystem, directoryPath: string): IFile
       exists(path) {
         return fsPromises.exists(resolveFullPath(path));
       },
-      stat(path) {
-        return fsPromises.stat(resolveFullPath(path));
-      },
+      stat: function stat(path: string, ...args: []) {
+        return fsPromises.stat(resolveFullPath(path), ...args);
+      } as IBaseFileSystemPromiseActions['stat'],
+      lstat: function lstat(path: string, ...args: []) {
+        return fsPromises.lstat(resolveFullPath(path), ...args);
+      } as IBaseFileSystemPromiseActions['lstat'],
       symlink(target, path, type) {
         return fsPromises.symlink(
           posixPath.isAbsolute(target) ? resolveFullPath(target) : target,
@@ -158,9 +158,6 @@ export function createDirectoryFs(fs: IFileSystem, directoryPath: string): IFile
     },
     copyFileSync(src, dest, ...args) {
       return fs.copyFileSync(resolveFullPath(src), resolveFullPath(dest), ...args);
-    },
-    lstatSync(path) {
-      return fs.lstatSync(resolveFullPath(path));
     },
     mkdirSync(path, ...args) {
       return fs.mkdirSync(resolveFullPath(path), ...args);
@@ -192,9 +189,12 @@ export function createDirectoryFs(fs: IFileSystem, directoryPath: string): IFile
     existsSync(path) {
       return fs.existsSync(resolveFullPath(path));
     },
-    statSync(path) {
-      return fs.statSync(resolveFullPath(path));
-    },
+    statSync: function statSync(path: string, ...args: []) {
+      return fs.statSync(resolveFullPath(path), ...args);
+    } as IBaseFileSystemSyncActions['statSync'],
+    lstatSync: function lstatSync(path: string, ...args: []) {
+      return fs.lstatSync(resolveFullPath(path), ...args);
+    } as IBaseFileSystemSyncActions['lstatSync'],
     symlinkSync(target, path, type) {
       return fs.symlinkSync(
         posixPath.isAbsolute(target) ? resolveFullPath(target) : target,

--- a/packages/memory/src/memory-fs.ts
+++ b/packages/memory/src/memory-fs.ts
@@ -9,6 +9,7 @@ import {
   BufferEncoding,
   IDirectoryEntry,
   IBaseFileSystemSyncActions,
+  StatOptions,
 } from '@file-services/types';
 import { FsErrorCodes } from './error-codes.js';
 import type {
@@ -292,20 +293,34 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
     return !!getNode(resolvePath(nodePath));
   }
 
-  function statSync(nodePath: string): IFileSystemStats {
+  function statSync(nodePath: string, options?: StatOptions & { throwIfNoEntry?: true }): IFileSystemStats;
+  function statSync(nodePath: string, options: StatOptions & { throwIfNoEntry: false }): IFileSystemStats | undefined;
+  function statSync(nodePath: string, options?: StatOptions): IFileSystemStats | undefined {
     const resolvedPath = resolvePath(nodePath);
     const node = getNode(resolvedPath);
     if (!node) {
-      throw createFsError(resolvedPath, FsErrorCodes.NO_FILE_OR_DIRECTORY, 'ENOENT');
+      const throwIfNoEntry = options?.throwIfNoEntry ?? true;
+      if (throwIfNoEntry) {
+        throw createFsError(resolvedPath, FsErrorCodes.NO_FILE_OR_DIRECTORY, 'ENOENT');
+      } else {
+        return undefined;
+      }
     }
     return node.entry;
   }
 
-  function lstatSync(nodePath: string): IFileSystemStats {
+  function lstatSync(nodePath: string, options?: StatOptions & { throwIfNoEntry?: true }): IFileSystemStats;
+  function lstatSync(nodePath: string, options: StatOptions & { throwIfNoEntry: false }): IFileSystemStats | undefined;
+  function lstatSync(nodePath: string, options?: StatOptions): IFileSystemStats | undefined {
     const resolvedPath = resolvePath(nodePath);
     const node = getRawNode(resolvedPath);
     if (!node) {
-      throw createFsError(resolvedPath, FsErrorCodes.NO_FILE_OR_DIRECTORY, 'ENOENT');
+      const throwIfNoEntry = options?.throwIfNoEntry ?? true;
+      if (throwIfNoEntry) {
+        throw createFsError(resolvedPath, FsErrorCodes.NO_FILE_OR_DIRECTORY, 'ENOENT');
+      } else {
+        return undefined;
+      }
     }
     return node.entry;
   }

--- a/packages/node/src/node-fs.ts
+++ b/packages/node/src/node-fs.ts
@@ -4,9 +4,16 @@ import { chdir, cwd } from 'process';
 import { promisify } from 'util';
 
 import { createFileSystem } from '@file-services/utils';
-import type { IBaseFileSystem, IFileSystem, IFileSystemPath } from '@file-services/types';
+import type {
+  IBaseFileSystem,
+  IFileSystem,
+  IFileSystemPath,
+  IFileSystemStats,
+  StatOptions,
+} from '@file-services/types';
 import { NodeWatchService, INodeWatchServiceOptions } from './watch-service.js';
 
+const { promises: fsPromises } = fs;
 const caseSensitive = !fs.existsSync(__filename.toUpperCase());
 
 export interface ICreateNodeFsOptions {
@@ -25,9 +32,79 @@ export function createBaseNodeFs(options?: ICreateNodeFsOptions): IBaseFileSyste
     watchService: new NodeWatchService(options && options.watchOptions),
     caseSensitive,
     ...fs,
+    statSync,
+    lstatSync,
     promises: {
       ...fs.promises,
+      stat: statPromise,
+      lstat: lstatPromise,
       exists: promisify(fs.exists),
     },
   };
+}
+
+function statSync(path: string, options?: StatOptions & { throwIfNoEntry?: true }): IFileSystemStats;
+function statSync(path: string, options: StatOptions & { throwIfNoEntry: false }): IFileSystemStats | undefined;
+function statSync(path: string, options?: StatOptions): IFileSystemStats | undefined {
+  try {
+    return fs.statSync(path, options as fs.StatOptions);
+  } catch (e) {
+    const throwIfNoEntry = options?.throwIfNoEntry ?? true;
+    if (throwIfNoEntry) {
+      throw e;
+    } else {
+      return undefined;
+    }
+  }
+}
+
+function lstatSync(path: string, options?: StatOptions & { throwIfNoEntry?: true }): IFileSystemStats;
+function lstatSync(path: string, options: StatOptions & { throwIfNoEntry: false }): IFileSystemStats | undefined;
+function lstatSync(path: string, options?: StatOptions): IFileSystemStats | undefined {
+  try {
+    return fs.lstatSync(path, options as fs.StatOptions);
+  } catch (e) {
+    const throwIfNoEntry = options?.throwIfNoEntry ?? true;
+    if (throwIfNoEntry) {
+      throw e;
+    } else {
+      return undefined;
+    }
+  }
+}
+
+async function statPromise(path: string, options?: StatOptions & { throwIfNoEntry?: true }): Promise<IFileSystemStats>;
+async function statPromise(
+  path: string,
+  options: StatOptions & { throwIfNoEntry: false }
+): Promise<IFileSystemStats | undefined>;
+async function statPromise(path: string, options?: StatOptions): Promise<IFileSystemStats | undefined> {
+  try {
+    return await fsPromises.stat(path, options as fs.StatOptions);
+  } catch (e) {
+    const throwIfNoEntry = options?.throwIfNoEntry ?? true;
+    if (throwIfNoEntry) {
+      throw e;
+    } else {
+      return undefined;
+    }
+  }
+}
+
+async function lstatPromise(path: string, options?: StatOptions & { throwIfNoEntry?: true }): Promise<IFileSystemStats>;
+async function lstatPromise(
+  path: string,
+  options: StatOptions & { throwIfNoEntry: false }
+): Promise<IFileSystemStats | undefined>;
+async function lstatPromise(path: string, options?: StatOptions): Promise<IFileSystemStats | undefined> {
+  try {
+    return await fsPromises.lstat(path, options as fs.StatOptions);
+  } catch (e) {
+    const throwIfNoEntry = options?.throwIfNoEntry ?? true;
+    if (throwIfNoEntry) {
+      throw e;
+    } else {
+      return undefined;
+    }
+  }
 }

--- a/packages/overlay/src/overlay-fs.ts
+++ b/packages/overlay/src/overlay-fs.ts
@@ -7,6 +7,7 @@ import type {
   ReadFileOptions,
   IDirectoryEntry,
   BufferEncoding,
+  StatOptions,
 } from '@file-services/types';
 import { createFileSystem } from '@file-services/utils';
 
@@ -57,36 +58,34 @@ export function createOverlayFs(
       }
       return lowerFs.readFileSync(resolvedLowerPath, ...args);
     } as IBaseFileSystemSyncActions['readFileSync'],
-    statSync(path) {
+    statSync: function (path: string, ...args: [StatOptions]) {
       const { resolvedLowerPath, resolvedUpperPath } = resolvePaths(path);
       if (resolvedUpperPath !== undefined) {
-        const { stackTraceLimit } = Error;
         try {
-          Error.stackTraceLimit = 0;
-          return upperFs.statSync(resolvedUpperPath);
+          const stats = upperFs.statSync(resolvedUpperPath, ...args);
+          if (stats) {
+            return stats;
+          }
         } catch {
           /**/
-        } finally {
-          Error.stackTraceLimit = stackTraceLimit;
         }
       }
-      return lowerFs.statSync(resolvedLowerPath);
-    },
-    lstatSync(path) {
+      return lowerFs.statSync(resolvedLowerPath, ...args);
+    } as IBaseFileSystemSyncActions['statSync'],
+    lstatSync: function lstatSync(path: string, ...args: [StatOptions]) {
       const { resolvedLowerPath, resolvedUpperPath } = resolvePaths(path);
       if (resolvedUpperPath !== undefined) {
-        const { stackTraceLimit } = Error;
         try {
-          Error.stackTraceLimit = 0;
-          return upperFs.lstatSync(resolvedUpperPath);
+          const stats = upperFs.lstatSync(resolvedUpperPath, ...args);
+          if (stats) {
+            return stats;
+          }
         } catch {
           /**/
-        } finally {
-          Error.stackTraceLimit = stackTraceLimit;
         }
       }
-      return lowerFs.lstatSync(resolvedLowerPath);
-    },
+      return lowerFs.lstatSync(resolvedLowerPath, ...args);
+    } as IBaseFileSystemSyncActions['lstatSync'],
     realpathSync(path) {
       const { resolvedLowerPath, resolvedUpperPath } = resolvePaths(path);
       if (resolvedUpperPath !== undefined) {
@@ -159,28 +158,34 @@ export function createOverlayFs(
       }
       return lowerPromises.readFile(resolvedLowerPath, ...args);
     } as IBaseFileSystemPromiseActions['readFile'],
-    async stat(path) {
+    stat: async function stat(path: string, ...args: [StatOptions]) {
       const { resolvedLowerPath, resolvedUpperPath } = resolvePaths(path);
       if (resolvedUpperPath !== undefined) {
         try {
-          return await upperPromises.stat(resolvedUpperPath);
+          const stats = await upperPromises.stat(resolvedUpperPath, ...args);
+          if (stats) {
+            return stats;
+          }
         } catch {
           /**/
         }
       }
-      return lowerPromises.stat(resolvedLowerPath);
-    },
-    async lstat(path) {
+      return lowerPromises.stat(resolvedLowerPath, ...args);
+    } as IBaseFileSystemPromiseActions['stat'],
+    lstat: async function lstat(path: string, ...args: [StatOptions]) {
       const { resolvedLowerPath, resolvedUpperPath } = resolvePaths(path);
       if (resolvedUpperPath !== undefined) {
         try {
-          return await upperPromises.lstat(resolvedUpperPath);
+          const stats = await upperPromises.lstat(resolvedUpperPath, ...args);
+          if (stats) {
+            return stats;
+          }
         } catch {
           /**/
         }
       }
-      return lowerPromises.lstat(resolvedLowerPath);
-    },
+      return lowerPromises.lstat(resolvedLowerPath, ...args);
+    } as IBaseFileSystemPromiseActions['lstat'],
     async realpath(path) {
       const { resolvedLowerPath, resolvedUpperPath } = resolvePaths(path);
       if (resolvedUpperPath !== undefined) {

--- a/packages/resolve/src/types.ts
+++ b/packages/resolve/src/types.ts
@@ -59,7 +59,10 @@ export type RequestResolver = (contextPath: string, request: string) => IResolut
  * Currently a subset of the sync base file system API.
  */
 export interface IResolutionFileSystem {
-  statSync(path: string): { isFile(): boolean; isDirectory(): boolean; birthtime: Date; mtime: Date };
+  statSync(
+    path: string,
+    options: { throwIfNoEntry: false }
+  ): { isFile(): boolean; isDirectory(): boolean; birthtime: Date; mtime: Date } | undefined;
   readFileSync(path: string, encoding: 'utf8'): string;
   realpathSync(path: string): string;
 

--- a/packages/test-kit/src/sync-base-fs-contract.ts
+++ b/packages/test-kit/src/sync-base-fs-contract.ts
@@ -67,7 +67,6 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
     describe('reading files', () => {
       it('can read the contents of a file', () => {
         const { fs, tempDirectoryPath } = testInput;
-
         const firstFilePath = fs.join(tempDirectoryPath, 'first-file');
         const secondFilePath = fs.join(tempDirectoryPath, 'second-file');
 
@@ -80,53 +79,36 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
 
       it('fails if reading a non-existing file', () => {
         const { fs, tempDirectoryPath } = testInput;
-
         const filePath = fs.join(tempDirectoryPath, 'missing-file');
-
-        const expectedToFail = () => fs.readFileSync(filePath, 'utf8');
-
-        expect(expectedToFail).to.throw('ENOENT');
+        expect(() => fs.readFileSync(filePath, 'utf8')).to.throw('ENOENT');
       });
 
       it('fails if reading a directory as a file', () => {
         const { fs, tempDirectoryPath } = testInput;
-        const expectedToFail = () => fs.readFileSync(tempDirectoryPath, 'utf8');
-
-        expect(expectedToFail).to.throw('EISDIR');
+        expect(() => fs.readFileSync(tempDirectoryPath, 'utf8')).to.throw('EISDIR');
       });
     });
 
     describe('removing files', () => {
       it('can remove files', () => {
         const { fs, tempDirectoryPath } = testInput;
-
         const filePath = fs.join(tempDirectoryPath, 'file');
-
         fs.writeFileSync(filePath, SAMPLE_CONTENT);
         fs.unlinkSync(filePath);
-
-        expect(() => fs.statSync(filePath)).to.throw('ENOENT');
+        expect(fs.statSync(filePath, { throwIfNoEntry: false })).to.equal(undefined);
       });
 
       it('fails if trying to remove a non-existing file', () => {
         const { fs, tempDirectoryPath } = testInput;
-
         const filePath = fs.join(tempDirectoryPath, 'missing-file');
-
-        const expectedToFail = () => fs.unlinkSync(filePath);
-
-        expect(expectedToFail).to.throw('ENOENT');
+        expect(() => fs.unlinkSync(filePath)).to.throw('ENOENT');
       });
 
       it('fails if trying to remove a directory as a file', () => {
         const { fs, tempDirectoryPath } = testInput;
-
         const directoryPath = fs.join(tempDirectoryPath, 'dir');
-
         fs.mkdirSync(directoryPath);
-        const expectedToFail = () => fs.unlinkSync(directoryPath);
-
-        expect(expectedToFail).to.throw(); // linux throws `EISDIR`, mac throws `EPERM`
+        expect(() => fs.unlinkSync(directoryPath)).to.throw(); // linux throws `EISDIR`, mac throws `EPERM`
       });
     });
 
@@ -351,7 +333,7 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
         fs.mkdirSync(directoryPath);
         fs.rmdirSync(directoryPath);
 
-        expect(() => fs.statSync(directoryPath)).to.throw('ENOENT');
+        expect(fs.statSync(directoryPath, { throwIfNoEntry: false })).to.equal(undefined);
       });
 
       it('fails if removing a non-empty directory', () => {
@@ -500,7 +482,7 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
 
         expect(fs.statSync(destinationPath).isFile()).to.equal(true);
         expect(fs.readFileSync(destinationPath, 'utf8')).to.eql(SAMPLE_CONTENT);
-        expect(() => fs.statSync(sourcePath)).to.throw('ENOENT');
+        expect(fs.statSync(sourcePath, { throwIfNoEntry: false })).to.equal(undefined);
       });
 
       it('updates mtime', () => {
@@ -571,7 +553,7 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
 
           expect(fs.statSync(destinationPath).isDirectory()).to.equal(true);
           expect(fs.readFileSync(fs.join(destinationPath, 'file'), 'utf8')).to.eql(SAMPLE_CONTENT);
-          expect(() => fs.statSync(sourcePath)).to.throw('ENOENT');
+          expect(fs.statSync(sourcePath, { throwIfNoEntry: false })).to.equal(undefined);
         });
 
         it(`allows renaming a directory over a non-existing directory`, () => {
@@ -609,7 +591,7 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
       fs.writeFileSync(filePath, SAMPLE_CONTENT);
 
       if (fs.caseSensitive) {
-        expect(() => fs.statSync(upperCaseFilePath)).to.throw('ENOENT');
+        expect(fs.statSync(upperCaseFilePath, { throwIfNoEntry: false })).to.equal(undefined);
       } else {
         expect(fs.statSync(upperCaseFilePath).isFile()).to.equal(true);
       }
@@ -749,7 +731,7 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
         fs.unlinkSync(targetPath);
 
         expect(fs.lstatSync(linkPath).isSymbolicLink()).to.eq(true);
-        expect(() => fs.statSync(linkPath)).to.throw('ENOENT');
+        expect(fs.statSync(linkPath, { throwIfNoEntry: false })).to.equal(undefined);
       });
 
       it('resolves the real path of a link', () => {

--- a/packages/types/src/base-api-async.ts
+++ b/packages/types/src/base-api-async.ts
@@ -6,6 +6,7 @@ import type {
   WriteFileOptions,
   ReadFileOptions,
   IDirectoryEntry,
+  StatOptions,
 } from './common-fs-types.js';
 import type { IFileSystemPath } from './path.js';
 import type { IWatchService } from './watch-api.js';
@@ -173,12 +174,15 @@ export interface IBaseFileSystemPromiseActions {
   /**
    * Get path's `IFileSystemStats`.
    */
-  stat(path: string): Promise<IFileSystemStats>;
-
+  stat(path: string, options?: StatOptions & { throwIfNoEntry?: true }): Promise<IFileSystemStats>;
+  stat(path: string, options: StatOptions & { throwIfNoEntry: false }): Promise<IFileSystemStats | undefined>;
+  stat(path: string, options?: StatOptions): Promise<IFileSystemStats | undefined>;
   /**
    * Get path's `IFileSystemStats`. Does not dereference symbolic links.
    */
-  lstat(path: string): Promise<IFileSystemStats>;
+  lstat(path: string, options?: StatOptions & { throwIfNoEntry?: true }): Promise<IFileSystemStats>;
+  lstat(path: string, options: StatOptions & { throwIfNoEntry: false }): Promise<IFileSystemStats | undefined>;
+  lstat(path: string, options?: StatOptions): Promise<IFileSystemStats | undefined>;
 
   /**
    * Gets the canonicalized absolute pathname.

--- a/packages/types/src/base-api-sync.ts
+++ b/packages/types/src/base-api-sync.ts
@@ -4,6 +4,7 @@ import type {
   WriteFileOptions,
   ReadFileOptions,
   IDirectoryEntry,
+  StatOptions,
 } from './common-fs-types.js';
 import type { IFileSystemPath } from './path.js';
 import type { IWatchService } from './watch-api.js';
@@ -89,12 +90,16 @@ export interface IBaseFileSystemSyncActions {
   /**
    * Get path's `IFileSystemStats`.
    */
-  statSync(path: string): IFileSystemStats;
+  statSync(path: string, options?: StatOptions & { throwIfNoEntry?: true }): IFileSystemStats;
+  statSync(path: string, options: StatOptions & { throwIfNoEntry: false }): IFileSystemStats | undefined;
+  statSync(path: string, options?: StatOptions): IFileSystemStats | undefined;
 
   /**
    * Get path's `IFileSystemStats`. Does not dereference symbolic links.
    */
-  lstatSync(path: string): IFileSystemStats;
+  lstatSync(path: string, options?: StatOptions & { throwIfNoEntry?: true }): IFileSystemStats;
+  lstatSync(path: string, options: StatOptions & { throwIfNoEntry: false }): IFileSystemStats | undefined;
+  lstatSync(path: string, options?: StatOptions): IFileSystemStats | undefined;
 
   /**
    * Get the canonicalized absolute pathname.

--- a/packages/types/src/common-fs-types.ts
+++ b/packages/types/src/common-fs-types.ts
@@ -20,6 +20,14 @@ declare global {
 export type CallbackFn<T> = (error: Error | null, value: T) => void;
 export type CallbackFnVoid = (error?: Error | null) => void;
 
+export interface StatOptions {
+  /**
+   * Whether an exception will be thrown if no file system entry exists, rather than returning `undefined`.
+   * @default true
+   */
+  throwIfNoEntry?: boolean;
+}
+
 export type WriteFileOptions =
   | {
       encoding?: BufferEncoding | null;

--- a/packages/typescript/src/create-host.ts
+++ b/packages/typescript/src/create-host.ts
@@ -109,15 +109,7 @@ export function createBaseHost(fs: IFileSystemSync): IBaseHost {
       }
     },
     getScriptVersion(filePath) {
-      const { stackTraceLimit } = Error;
-      try {
-        Error.stackTraceLimit = 0;
-        return `${statSync(filePath).mtime.getTime()}`;
-      } catch {
-        return `${Date.now()}`;
-      } finally {
-        Error.stackTraceLimit = stackTraceLimit;
-      }
+      return `${statSync(filePath, { throwIfNoEntry: false })?.mtime.getTime() ?? Date.now()}`;
     },
     useCaseSensitiveFileNames: caseSensitive,
     getCanonicalFileName: caseSensitive ? identity : toLowerCase,

--- a/packages/utils/src/sync-to-async-fs.ts
+++ b/packages/utils/src/sync-to-async-fs.ts
@@ -33,12 +33,12 @@ export function syncToAsyncFs(syncFs: IBaseFileSystemSync): IBaseFileSystemAsync
       async exists(nodePath) {
         return syncFs.existsSync(nodePath);
       },
-      async stat(nodePath) {
-        return syncFs.statSync(nodePath);
-      },
-      async lstat(nodePath) {
-        return syncFs.lstatSync(nodePath);
-      },
+      stat: async function stat(...args: [string]) {
+        return syncFs.statSync(...args);
+      } as IBaseFileSystemPromiseActions['stat'],
+      lstat: async function lstat(...args: [string]) {
+        return syncFs.lstatSync(...args);
+      } as IBaseFileSystemPromiseActions['lstat'],
       async realpath(nodePath) {
         return syncFs.realpathSync(nodePath);
       },
@@ -65,8 +65,8 @@ export function syncToAsyncFs(syncFs: IBaseFileSystemSync): IBaseFileSystemAsync
     readdir: callbackify(syncFs.readdirSync) as IBaseFileSystemAsync['readdir'],
     mkdir: callbackify(syncFs.mkdirSync) as unknown as IBaseFileSystemAsync['mkdir'],
     rmdir: callbackify(syncFs.rmdirSync),
-    stat: callbackify(syncFs.statSync),
-    lstat: callbackify(syncFs.lstatSync),
+    stat: (callbackify(syncFs.statSync) as unknown) as IBaseFileSystemAsync['stat'],
+    lstat: (callbackify(syncFs.lstatSync) as unknown) as IBaseFileSystemAsync['lstat'],
     realpath: callbackify(syncFs.realpathSync),
     rename: callbackify(syncFs.renameSync),
     readlink: callbackify(syncFs.readlinkSync),


### PR DESCRIPTION
- wrapped/polyfilled for older node versions.
- implement memory fs support.
- adjusted resolver, base-host and other abstractions to make use of the new flag