### PR TITLE
feat(resolve): add visitedPaths to result

### DIFF
--- a/packages/commonjs/test/cjs-module-system.spec.ts
+++ b/packages/commonjs/test/cjs-module-system.spec.ts
@@ -211,6 +211,7 @@ module.exports = global;`,
 
     const resolver = (_contextPath: string, request: string) => ({
       resolvedFile: request === 'some-package' ? '/src/package.js' : undefined,
+      visitedPaths: new Set<string>(),
     });
 
     const { requireModule } = createCjsModuleSystem({ fs, resolver });

--- a/packages/resolve/src/types.ts
+++ b/packages/resolve/src/types.ts
@@ -58,6 +58,11 @@ export interface IResolutionOutput {
    * filePath this request pointed to.
    */
   originalFilePath?: string;
+
+  /**
+   * All paths resolver visited before getting to `resolvedFile`.
+   */
+  visitedPaths: Set<string>;
 }
 
 /**

--- a/packages/resolve/test/request-resolver.spec.ts
+++ b/packages/resolve/test/request-resolver.spec.ts
@@ -749,4 +749,27 @@ describe('request resolver', () => {
       );
     });
   });
+
+  describe('tracking', () => {
+    it('lists all paths it visited to resolve the request', () => {
+      const fs = createMemoryFs({
+        'package.json': stringifyPackageJson({}),
+        src: {
+          'index.js': EMPTY,
+        },
+      });
+      const resolveRequest = createRequestResolver({ fs });
+
+      const resolutionOutput = resolveRequest('/', './src');
+      expect(resolutionOutput).to.be.resolvedTo('/src/index.js');
+      expect(Array.from(resolutionOutput.visitedPaths)).to.eql([
+        '/package.json',
+        '/src',
+        '/src.js',
+        '/src.json',
+        '/src/index',
+        '/src/index.js',
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
- to be able to cache and invalidate resolutions fully
- might still have a small gap with the realpath of package.json files