### PR TITLE
breaking: delete removeSync and promises.remove

### DIFF
--- a/packages/test-kit/src/async-fs-contract.ts
+++ b/packages/test-kit/src/async-fs-contract.ts
@@ -107,53 +107,6 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
     });
 
-    describe('remove', () => {
-      it('should delete directory recursively', async () => {
-        const { fs, tempDirectoryPath } = testInput;
-
-        const directoryPath = fs.join(tempDirectoryPath, 'dir');
-
-        await fs.promises.populateDirectory(directoryPath, {
-          'file1.ts': '',
-          'file2.ts': '',
-          folder1: {
-            'file1.ts': '',
-            'file2.ts': '',
-            'file3.ts': '',
-          },
-          folder2: {
-            'file1.ts': '',
-            'file2.ts': '',
-            'file3.ts': '',
-          },
-        });
-
-        await fs.promises.remove(directoryPath);
-
-        expect(await fs.promises.directoryExists(directoryPath)).to.equal(false);
-      });
-
-      it('should delete a file', async () => {
-        const { fs, tempDirectoryPath } = testInput;
-
-        const filePath = fs.join(tempDirectoryPath, 'file');
-
-        await fs.promises.writeFile(filePath, '');
-
-        await fs.promises.remove(filePath);
-
-        expect(await fs.promises.fileExists(tempDirectoryPath)).to.equal(false);
-      });
-
-      it('should fail on nonexistant', async () => {
-        const { fs, tempDirectoryPath } = testInput;
-
-        const filePath = fs.join(tempDirectoryPath, 'file');
-
-        return expect(fs.promises.remove(filePath)).to.eventually.rejectedWith(/ENOENT/);
-      });
-    });
-
     const fileName = 'a.json';
     const anotherFileName = 'b.json';
 

--- a/packages/test-kit/src/sync-fs-contract.ts
+++ b/packages/test-kit/src/sync-fs-contract.ts
@@ -138,56 +138,6 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
     });
 
-    describe('removeSync', () => {
-      it('should delete directory recursively', () => {
-        const { fs, tempDirectoryPath } = testInput;
-
-        const directoryPath = fs.join(tempDirectoryPath, 'dir');
-
-        fs.populateDirectorySync(directoryPath, {
-          'file1.ts': '',
-          'file2.ts': '',
-          folder1: {
-            'file1.ts': '',
-            'file2.ts': '',
-            'file3.ts': '',
-          },
-          folder2: {
-            'file1.ts': '',
-            'file2.ts': '',
-            'file3.ts': '',
-          },
-        });
-
-        fs.removeSync(directoryPath);
-
-        expect(fs.directoryExistsSync(directoryPath)).to.equal(false);
-      });
-
-      it('should delete a file', () => {
-        const { fs, tempDirectoryPath } = testInput;
-
-        const filePath = fs.join(tempDirectoryPath, 'file');
-
-        fs.writeFileSync(filePath, '');
-
-        expect(fs.readdirSync(tempDirectoryPath)).to.deep.equal(['file']);
-
-        fs.removeSync(filePath);
-
-        expect(fs.fileExistsSync(tempDirectoryPath)).to.equal(false);
-      });
-
-      it('should fail on nonexistant', () => {
-        const { fs, tempDirectoryPath } = testInput;
-
-        const filePath = fs.join(tempDirectoryPath, 'file');
-
-        const thrower = () => fs.removeSync(filePath);
-        expect(thrower).to.throw(/ENOENT/);
-      });
-    });
-
     const fileName = 'a.json';
     const anotherFileName = 'b.json';
 

--- a/packages/types/src/extended-api-async.ts
+++ b/packages/types/src/extended-api-async.ts
@@ -64,11 +64,6 @@ export interface IFileSystemExtendedPromiseActions {
   populateDirectory(directoryPath: string, contents: IDirectoryContents): Promise<string[]>;
 
   /**
-   * Recursively remove a path.
-   */
-  remove(path: string): Promise<void>;
-
-  /**
    * Read a file and parse it using `JSON.parse`.
    *
    * @param filePath path pointing to a `json` file.

--- a/packages/types/src/extended-api-sync.ts
+++ b/packages/types/src/extended-api-sync.ts
@@ -60,11 +60,6 @@ export interface IFileSystemExtendedSyncActions {
   populateDirectorySync(directoryPath: string, contents: IDirectoryContents): string[];
 
   /**
-   * Recursively remove a path.
-   */
-  removeSync(path: string): void;
-
-  /**
    * Read a file and parse it using `JSON.parse`.
    *
    * @param filePath path pointing to a `json` file.


### PR DESCRIPTION
no need for this extended API, now that the base has fs.rmSync and fs.promises.rm with the force and recursive flags