### PR TITLE
fix: consistent statSync/lstatSync behavior

### DIFF
--- a/packages/memory/src/error-codes.ts
+++ b/packages/memory/src/error-codes.ts
@@ -9,6 +9,7 @@ export enum FsErrorCodes {
 
   CONTAINING_NOT_EXISTS = 'ENOENT: containing directory does not exist',
   DIRECTORY_NOT_EMPTY = 'ENOTEMPTY: directory is not empty',
+  NOT_A_DIRECTORY = 'ENOTDIR: not a directory',
 
   PATH_ALREADY_EXISTS = 'EEXIST: path already exists',
 }

--- a/packages/memory/src/memory-fs.ts
+++ b/packages/memory/src/memory-fs.ts
@@ -333,6 +333,11 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
   ): IFileSystemStats | undefined;
   function statSync(nodePath: string, options?: StatSyncOptions): IFileSystemStats | undefined {
     const resolvedPath = resolvePath(nodePath);
+    const parentPath = posixPath.dirname(resolvedPath);
+    const parentNode = getNode(parentPath);
+    if (parentNode && parentNode.type !== 'dir') {
+      throw createFsError(resolvedPath, FsErrorCodes.NOT_A_DIRECTORY, 'ENOTDIR');
+    }
     const node = getNode(resolvedPath);
     if (!node) {
       const throwIfNoEntry = options?.throwIfNoEntry ?? true;
@@ -352,7 +357,12 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
   ): IFileSystemStats | undefined;
   function lstatSync(nodePath: string, options?: StatSyncOptions): IFileSystemStats | undefined {
     const resolvedPath = resolvePath(nodePath);
-    const node = getRawNode(resolvedPath);
+    const parentPath = posixPath.dirname(resolvedPath);
+    const parentNode = getNode(parentPath);
+    if (parentNode && parentNode.type !== 'dir') {
+      throw createFsError(resolvedPath, FsErrorCodes.NOT_A_DIRECTORY, 'ENOTDIR');
+    }
+    const node = parentNode?.contents.get(posixPath.basename(resolvedPath));
     if (!node) {
       const throwIfNoEntry = options?.throwIfNoEntry ?? true;
       if (throwIfNoEntry) {

--- a/packages/node/src/node-fs.ts
+++ b/packages/node/src/node-fs.ts
@@ -15,7 +15,7 @@ import type {
 import { NodeWatchService, INodeWatchServiceOptions } from './watch-service.js';
 
 const nodeMajor = parseInt(process.versions.node, 10);
-const needsStatPolyfill = nodeMajor < 14;
+const needsStatPolyfill = nodeMajor < 14; // node 12 has no throwIfNoEntry
 const caseSensitive = !fs.existsSync(__filename.toUpperCase());
 const fsPromisesExists = promisify(fs.exists);
 
@@ -53,7 +53,7 @@ function statSync(path: string, options?: StatSyncOptions): IFileSystemStats | u
     return fs.statSync(path, options);
   } catch (e) {
     const throwIfNoEntry = options?.throwIfNoEntry ?? true;
-    if (throwIfNoEntry) {
+    if (throwIfNoEntry || (e as NodeJS.ErrnoException)?.code !== 'ENOENT') {
       throw e;
     } else {
       return undefined;
@@ -68,7 +68,7 @@ function lstatSync(path: string, options?: StatSyncOptions): IFileSystemStats | 
     return fs.lstatSync(path, options);
   } catch (e) {
     const throwIfNoEntry = options?.throwIfNoEntry ?? true;
-    if (throwIfNoEntry) {
+    if (throwIfNoEntry || (e as NodeJS.ErrnoException)?.code !== 'ENOENT') {
       throw e;
     } else {
       return undefined;

--- a/packages/test-kit/src/sync-base-fs-contract.ts
+++ b/packages/test-kit/src/sync-base-fs-contract.ts
@@ -87,6 +87,20 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
         const { fs, tempDirectoryPath } = testInput;
         expect(() => fs.readFileSync(tempDirectoryPath, 'utf8')).to.throw('EISDIR');
       });
+
+      it('fails if using statSync or lstatSync on a target path with parent as a file', () => {
+        const { fs, tempDirectoryPath } = testInput;
+        const filePath = fs.join(tempDirectoryPath, 'file');
+
+        fs.writeFileSync(filePath, SAMPLE_CONTENT);
+
+        const targetUnderFile = fs.join(filePath, 'broken-target');
+        expect(() => fs.statSync(targetUnderFile)).to.throw(/ENOTDIR|ENOENT/);
+        expect(() => fs.statSync(targetUnderFile, { throwIfNoEntry: false })).to.throw(/ENOTDIR|ENOENT/);
+
+        expect(() => fs.lstatSync(targetUnderFile)).to.throw(/ENOTDIR|ENOENT/);
+        expect(() => fs.lstatSync(targetUnderFile, { throwIfNoEntry: false })).to.throw(/ENOTDIR|ENOENT/);
+      });
     });
 
     describe('removing files', () => {


### PR DESCRIPTION
even with `throwIfNoEntry`, node still throws when other errors occur. we swallowed these in several places.

added a test case