### PR TITLE
feat(commonjs): add filePath to evaluation errors

### DIFF
--- a/packages/commonjs/src/base-cjs-module-system.ts
+++ b/packages/commonjs/src/base-cjs-module-system.ts
@@ -109,6 +109,12 @@ export function createBaseCjsModuleSystem(options: IBaseModuleSystemOptions): IC
       moduleFn(...Object.values(moduleBuiltins));
     } catch (e) {
       loadedModules.delete(filePath);
+
+      // switch to Error.cause once more places support it
+      if (e instanceof Error && !(e as { filePath?: string }).filePath) {
+        (e as { filePath?: string }).filePath = filePath;
+      }
+
       throw e;
     }
 

--- a/packages/commonjs/test/cjs-module-system.spec.ts
+++ b/packages/commonjs/test/cjs-module-system.spec.ts
@@ -291,6 +291,13 @@ module.exports = global;`,
     const { requireModule } = createCjsModuleSystem({ fs });
 
     expect(() => requireModule(sampleFilePath)).to.throw('Thanos is coming!');
+    let e: unknown;
+    try {
+      requireModule(sampleFilePath);
+    } catch (error) {
+      e = error;
+    }
+    expect(e).to.haveOwnProperty('filePath', sampleFilePath);
 
     fs.writeFileSync(sampleFilePath, `module.exports = 1`);
 


### PR DESCRIPTION
closes #593 

a cleaner way to do it would be `Error.cause`, but we'll wait for additional environments and error handlers to properly support it