### PR TITLE
fix(find-files): avoid circularities due to links

### DIFF
--- a/packages/types/src/common-fs-types.ts
+++ b/packages/types/src/common-fs-types.ts
@@ -131,11 +131,6 @@ export interface IFileSystemDescriptor {
    * @example '/path/to/package.json'
    */
   path: string;
-
-  /**
-   * Stats for the path
-   */
-  stats: IFileSystemStats;
 }
 
 export interface IWalkOptions {


### PR DESCRIPTION
use `withFileTypes`, now available. this will save fs operations as well.