### PR TITLE
feat: expose chmodSync and promises.chmod

### DIFF
--- a/packages/directory/src/directory-fs.ts
+++ b/packages/directory/src/directory-fs.ts
@@ -158,6 +158,9 @@ export function createDirectoryFs(fs: IFileSystem, directoryPath: string): IFile
       writeFile(path, ...args) {
         return fsPromises.writeFile(path === '' ? '' : resolveFullPath(path), ...args);
       },
+      chmod(path, mode) {
+        return fsPromises.chmod(resolveFullPath(path), mode);
+      },
     },
     copyFileSync(src, dest, ...args) {
       return fs.copyFileSync(resolveFullPath(src), resolveFullPath(dest), ...args);
@@ -213,6 +216,9 @@ export function createDirectoryFs(fs: IFileSystem, directoryPath: string): IFile
     },
     writeFileSync(path, ...args: [string, WriteFileOptions]) {
       return fs.writeFileSync(path === '' ? '' : resolveFullPath(path), ...args);
+    },
+    chmodSync(path, mode) {
+      return fs.chmodSync(resolveFullPath(path), mode);
     },
     copyFile: function copyFile(srcPath: string, destPath: string, ...args: [CallbackFnVoid]) {
       fs.copyFile(resolveFullPath(srcPath), resolveFullPath(destPath), ...args);

--- a/packages/memory/src/memory-fs.ts
+++ b/packages/memory/src/memory-fs.ts
@@ -115,6 +115,7 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
     symlinkSync,
     unlinkSync,
     writeFileSync,
+    chmodSync: () => undefined,
   };
 
   function resolvePath(...pathSegments: string[]): string {

--- a/packages/types/src/base-api-async.ts
+++ b/packages/types/src/base-api-async.ts
@@ -206,4 +206,9 @@ export interface IBaseFileSystemPromiseActions {
    * Removes files and directories.
    */
   rm(path: string, options?: RmOptions): Promise<void>;
+
+  /**
+   * Changes the permissions of a file.
+   */
+  chmod(path: string, mode: number | string): Promise<void>;
 }

--- a/packages/types/src/base-api-sync.ts
+++ b/packages/types/src/base-api-sync.ts
@@ -127,4 +127,9 @@ export interface IBaseFileSystemSyncActions {
    * Removes files and directories.
    */
   rmSync(path: string, options?: RmOptions): void;
+
+  /**
+   * Changes the permissions of a file.
+   */
+  chmodSync(path: string, mode: number | string): void;
 }

--- a/packages/utils/src/sync-to-async-fs.ts
+++ b/packages/utils/src/sync-to-async-fs.ts
@@ -57,6 +57,9 @@ export function syncToAsyncFs(syncFs: IBaseFileSystemSync): IBaseFileSystemAsync
       async rm(...args) {
         return syncFs.rmSync(...args);
       },
+      async chmod(...args) {
+        return syncFs.chmodSync(...args);
+      },
     },
     exists(nodePath, callback) {
       callback(syncFs.existsSync(nodePath));


### PR DESCRIPTION
use node's native API for node implementation, and noop for memory