### PR TITLE
fix(overlay): fix realpath resolution for parent dir of base dir

### DIFF
--- a/packages/overlay/src/overlay-fs.ts
+++ b/packages/overlay/src/overlay-fs.ts
@@ -28,7 +28,11 @@ export function createOverlayFs(
     const resolvedLowerPath = lowerFs.resolve(path);
     const relativeToBase = lowerFs.relative(baseDirectoryPath, resolvedLowerPath);
 
-    if (!relativeToBase.startsWith(lowerFsRelativeUp) && !lowerFs.isAbsolute(lowerFsRelativeUp)) {
+    if (
+      relativeToBase !== '..' &&
+      !relativeToBase.startsWith(lowerFsRelativeUp) &&
+      !lowerFs.isAbsolute(lowerFsRelativeUp)
+    ) {
       return { resolvedLowerPath, resolvedUpperPath: relativeToBase.replace(/\\/g, '/') };
     } else {
       return { resolvedLowerPath };

--- a/packages/overlay/test/overlay.spec.ts
+++ b/packages/overlay/test/overlay.spec.ts
@@ -31,7 +31,7 @@ describe('overlay fs', () => {
       [srcFile1Path]: sampleContent1,
       [srcFile2Path]: sampleContent2,
     });
-    const higher = createMemoryFs({
+    const upper = createMemoryFs({
       [rootFile1Path]: sampleContent3,
       [srcFile2Path]: sampleContent3,
       [folderPath]: {},
@@ -43,7 +43,7 @@ describe('overlay fs', () => {
       directoryExistsSync,
       existsSync,
       promises: { readFile, fileExists, directoryExists, exists },
-    } = createOverlayFs(lower, higher);
+    } = createOverlayFs(lower, upper);
 
     expect(readFileSync(srcFile1Path, 'utf8')).to.equal(sampleContent1);
     expect(readFileSync(srcFile2Path, 'utf8')).to.equal(sampleContent3);
@@ -117,18 +117,17 @@ describe('overlay fs', () => {
   });
 
   it(`resolves real path when given the parent dir of the base dir`, async function () {
-    const lower = createMemoryFs({
+    const upper = createMemoryFs({
       '/src/a': {},
     });
-
-    const higher = createMemoryFs({
-      '/src/a': {},
+    const lower = createMemoryFs({
+      '/src': {},
     });
 
     const {
       realpathSync,
       promises: { realpath },
-    } = createOverlayFs(lower, higher, '/src/a');
+    } = createOverlayFs(lower, upper, '/src/a');
 
     expect(realpathSync('/src')).to.eql('/src');
     expect(await realpath('/src')).to.eql('/src');

--- a/packages/overlay/test/overlay.spec.ts
+++ b/packages/overlay/test/overlay.spec.ts
@@ -115,4 +115,22 @@ describe('overlay fs', () => {
     expect(readdirSync(srcPath, { withFileTypes: true })).to.have.lengthOf(1);
     expect(await readdir(srcPath, { withFileTypes: true })).to.have.lengthOf(1);
   });
+
+  it(`resolves real path when given the parent dir of the base dir`, async function () {
+    const lower = createMemoryFs({
+      '/src/a': {},
+    });
+
+    const higher = createMemoryFs({
+      '/src/a': {},
+    });
+
+    const {
+      realpathSync,
+      promises: { realpath },
+    } = createOverlayFs(lower, higher, '/src/a');
+
+    expect(realpathSync('/src')).to.eql('/src');
+    expect(await realpath('/src')).to.eql('/src');
+  });
 });


### PR DESCRIPTION
* fixes a case when the base directory is the child directory of the path we are trying to get realpath from