### PR TITLE
Barak/binary-file-support-finishes

### DIFF
--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -30,7 +30,7 @@ export type IFsMemNodeType = IFsMemFileNode | IFsMemDirectoryNode | IFsMemSymlin
 
 export interface IFsMemFileNode extends IFsMemNode {
   type: 'file';
-  contents: string;
+  contents: Uint8Array;
 }
 
 export interface IFsMemDirectoryNode extends IFsMemNode {

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -5,6 +5,7 @@ import type {
   IFileSystemSync,
   IFileSystemStats,
   IDirectoryEntry,
+  BufferEncoding,
 } from '@file-services/types';
 
 export interface IMemFileSystem extends IFileSystemSync, IFileSystemAsync {
@@ -28,9 +29,13 @@ export interface IFsMemNode {
 
 export type IFsMemNodeType = IFsMemFileNode | IFsMemDirectoryNode | IFsMemSymlinkNode;
 
+export type IEncodingKeys = Exclude<BufferEncoding, 'utf-8' | 'ucs-2'>;
+
+export type IEncodingMap = Map<IEncodingKeys, Uint8Array | string>;
+
 export interface IFsMemFileNode extends IFsMemNode {
   type: 'file';
-  contents: Uint8Array;
+  contents: IEncodingMap;
 }
 
 export interface IFsMemDirectoryNode extends IFsMemNode {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,5 +1,5 @@
-import { createNodeFs } from './node-fs.js';
 import type { IFileSystem } from '@file-services/types';
+import { createNodeFs } from './node-fs.js';
 
 export * from './node-fs.js';
 export * from './watch-service.js';

--- a/packages/node/test/node-fs.nodespec.ts
+++ b/packages/node/test/node-fs.nodespec.ts
@@ -1,4 +1,5 @@
 import { platform } from 'os';
+import { expect } from 'chai';
 import { syncBaseFsContract, asyncBaseFsContract, asyncFsContract, syncFsContract } from '@file-services/test-kit';
 import { createTempDirectory } from 'create-temp-directory';
 import { createNodeFs } from '@file-services/node';
@@ -33,4 +34,10 @@ describe('Node File System Implementation', function () {
 
   asyncFsContract(testProvider);
   syncFsContract(testProvider);
+
+  it('returns instances of Buffer when reading binary', async () => {
+    const fs = createNodeFs();
+    expect(fs.readFileSync(__filename)).to.be.instanceOf(Buffer);
+    expect(await fs.promises.readFile(__filename)).to.be.instanceOf(Buffer);
+  });
 });

--- a/packages/overlay/src/overlay-fs.ts
+++ b/packages/overlay/src/overlay-fs.ts
@@ -267,8 +267,8 @@ export function createOverlayFs(
     },
     readFile(
       path: string,
-      options?: ReadFileOptions | CallbackFn<Buffer>,
-      callback?: CallbackFn<string> | CallbackFn<Buffer> | CallbackFn<string | Buffer>
+      options?: ReadFileOptions | CallbackFn<Uint8Array>,
+      callback?: CallbackFn<string> | CallbackFn<Uint8Array> | CallbackFn<string | Uint8Array>
     ): void {
       if (typeof options === 'function') {
         callback = options;
@@ -280,13 +280,13 @@ export function createOverlayFs(
       if (resolvedUpperPath !== undefined) {
         upperFs.readFile(resolvedUpperPath, options, (upperError, upperValue) => {
           if (upperError) {
-            lowerFs.readFile(resolvedLowerPath, options as BufferEncoding, callback as CallbackFn<string | Buffer>);
+            lowerFs.readFile(resolvedLowerPath, options as BufferEncoding, callback as CallbackFn<string | Uint8Array>);
           } else {
-            (callback as CallbackFn<string | Buffer>)(upperError, upperValue);
+            (callback as CallbackFn<string | Uint8Array>)(upperError, upperValue);
           }
         });
       } else {
-        lowerFs.readFile(resolvedLowerPath, options, callback as CallbackFn<string | Buffer>);
+        lowerFs.readFile(resolvedLowerPath, options, callback as CallbackFn<string | Uint8Array>);
       }
     },
     stat(path, callback) {

--- a/packages/test-kit/src/sync-base-fs-contract.ts
+++ b/packages/test-kit/src/sync-base-fs-contract.ts
@@ -91,6 +91,10 @@ export function syncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseF
         expect(fs.readFileSync(firstFilePath, 'utf8'), 'contents of first-file').to.eql(SAMPLE_CONTENT);
         expect(fs.readFileSync(secondFilePath, 'utf8'), 'contents of second-file').to.eql(DIFFERENT_CONTENT);
         expect(fs.readFileSync(firstFilePath), 'binary contents of first-file').to.be.instanceOf(Uint8Array);
+
+        // expect(() => fs.readFileSync(firstFilePath, 'base64'), 'base64 encoded of first-file').to.throw(
+        //   `The "base64" encoding is not supported`
+        // );
       });
 
       it('fails if reading a non-existing file', () => {

--- a/packages/types/src/base-api-async.ts
+++ b/packages/types/src/base-api-async.ts
@@ -38,19 +38,19 @@ export interface IBaseFileSystemCallbackActions {
   readFile(
     path: string,
     options: { encoding?: null; flag?: string } | undefined | null,
-    callback: CallbackFn<Buffer>
+    callback: CallbackFn<Uint8Array>
   ): void;
   readFile(
     path: string,
     options: { encoding: BufferEncoding; flag?: string } | BufferEncoding,
     callback: CallbackFn<string>
   ): void;
-  readFile(path: string, options: ReadFileOptions | undefined, callback: CallbackFn<string | Buffer>): void;
-  readFile(path: string, callback: CallbackFn<Buffer>): void;
+  readFile(path: string, options: ReadFileOptions | undefined, callback: CallbackFn<string | Uint8Array>): void;
+  readFile(path: string, callback: CallbackFn<Uint8Array>): void;
 
   /**
    * Write data to a file, replacing the file if already exists.
-   * `encoding` is used when a string `content` (not `Buffer`) was provided (with default 'utf8').
+   * `encoding` is used when a string `content` (not `Uint8Array`) was provided (with default 'utf8').
    */
   writeFile(path: string, data: string | Uint8Array, options: WriteFileOptions, callback: CallbackFnVoid): void;
   writeFile(path: string, data: string | Uint8Array, callback: CallbackFnVoid): void;
@@ -129,13 +129,13 @@ export interface IBaseFileSystemPromiseActions {
   /**
    * Read the entire contents of a file.
    */
-  readFile(path: string, options?: { encoding?: null; flag?: string } | null): Promise<Buffer>;
+  readFile(path: string, options?: { encoding?: null; flag?: string } | null): Promise<Uint8Array>;
   readFile(path: string, options: { encoding: BufferEncoding; flag?: string } | BufferEncoding): Promise<string>;
-  readFile(path: string, options?: ReadFileOptions): Promise<string | Buffer>;
+  readFile(path: string, options?: ReadFileOptions): Promise<string | Uint8Array>;
 
   /**
    * Write data to a file, replacing the file if already exists.
-   * `encoding` is used when a string `content` (not `Buffer`) was provided (with default 'utf8').
+   * `encoding` is used when a string `content` (not `Uint8Array`) was provided (with default 'utf8').
    */
   writeFile(path: string, data: string | Uint8Array, options?: WriteFileOptions): Promise<void>;
 

--- a/packages/types/src/base-api-sync.ts
+++ b/packages/types/src/base-api-sync.ts
@@ -46,13 +46,13 @@ export interface IBaseFileSystemSyncActions {
   /**
    * Read the entire contents of a file.
    */
-  readFileSync(path: string, options?: { encoding?: null; flag?: string } | null): Buffer;
+  readFileSync(path: string, options?: { encoding?: null; flag?: string } | null): Uint8Array;
   readFileSync(path: string, options: { encoding: BufferEncoding; flag?: string } | BufferEncoding): string;
-  readFileSync(path: string, options?: ReadFileOptions): string | Buffer;
+  readFileSync(path: string, options?: ReadFileOptions): string | Uint8Array;
 
   /**
    * Write data to a file, replacing the file if already exists.
-   * `encoding` is used when a string `content` (not `Buffer`) was provided (with default 'utf8').
+   * `encoding` is used when a string `content` (not `Uint8Array`) was provided (with default 'utf8').
    */
   writeFileSync(path: string, data: string | Uint8Array, options?: WriteFileOptions): void;
 

--- a/packages/types/src/common-fs-types.ts
+++ b/packages/types/src/common-fs-types.ts
@@ -10,13 +10,6 @@ export type BufferEncoding =
   | 'binary'
   | 'hex';
 
-// use global augmentation so that users without @types/node will have a partial Buffer interface
-declare global {
-  interface Buffer {
-    toString(ecoding?: BufferEncoding): string;
-  }
-}
-
 export type CallbackFn<T> = (error: Error | null, value: T) => void;
 export type CallbackFnVoid = (error?: Error | null) => void;
 
@@ -53,8 +46,8 @@ export enum FileSystemConstants {
   COPYFILE_EXCL = 1,
 }
 
-export interface IDirectoryContents {
-  [nodeName: string]: string | IDirectoryContents;
+export interface IDirectoryContents<T extends Uint8Array | string = string> {
+  [nodeName: string]: T | IDirectoryContents<T>;
 }
 
 /**

--- a/packages/types/src/extended-api-async.ts
+++ b/packages/types/src/extended-api-async.ts
@@ -61,7 +61,7 @@ export interface IFileSystemExtendedPromiseActions {
    *
    * @returns absolute paths of written files.
    */
-  populateDirectory(directoryPath: string, contents: IDirectoryContents): Promise<string[]>;
+  populateDirectory(directoryPath: string, contents: IDirectoryContents<string | Uint8Array>): Promise<string[]>;
 
   /**
    * Read a file and parse it using `JSON.parse`.

--- a/packages/types/src/extended-api-sync.ts
+++ b/packages/types/src/extended-api-sync.ts
@@ -57,7 +57,7 @@ export interface IFileSystemExtendedSyncActions {
    *
    * @returns absolute paths of written files.
    */
-  populateDirectorySync(directoryPath: string, contents: IDirectoryContents): string[];
+  populateDirectorySync(directoryPath: string, contents: IDirectoryContents<string | Uint8Array>): string[];
 
   /**
    * Read a file and parse it using `JSON.parse`.

--- a/packages/utils/src/create-extended-api.ts
+++ b/packages/utils/src/create-extended-api.ts
@@ -93,12 +93,12 @@ export function createExtendedSyncActions(baseFs: IBaseFileSystemSync): IFileSys
     }
   }
 
-  function populateDirectorySync(directoryPath: string, contents: IDirectoryContents): string[] {
+  function populateDirectorySync(directoryPath: string, contents: IDirectoryContents<string | Uint8Array>): string[] {
     const filePaths: string[] = [];
     ensureDirectorySync(directoryPath);
     for (const [nodeName, nodeValue] of Object.entries(contents)) {
       const nodePath = join(directoryPath, nodeName);
-      if (typeof nodeValue === 'string') {
+      if (typeof nodeValue === 'string' || nodeValue instanceof Uint8Array) {
         ensureDirectorySync(dirname(nodePath));
         writeFileSync(nodePath, nodeValue);
         filePaths.push(nodePath);
@@ -265,12 +265,15 @@ export function createExtendedFileSystemPromiseActions(
     }
   }
 
-  async function populateDirectory(directoryPath: string, contents: IDirectoryContents): Promise<string[]> {
+  async function populateDirectory(
+    directoryPath: string,
+    contents: IDirectoryContents<string | Uint8Array>
+  ): Promise<string[]> {
     const filePaths: string[] = [];
     await ensureDirectory(directoryPath);
     for (const [nodeName, nodeValue] of Object.entries(contents)) {
       const nodePath = join(directoryPath, nodeName);
-      if (typeof nodeValue === 'string') {
+      if (typeof nodeValue === 'string' || nodeValue instanceof Uint8Array) {
         await ensureDirectory(dirname(nodePath));
         await writeFile(nodePath, nodeValue);
         filePaths.push(nodePath);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
     // "incremental": true,                         /* Enable incremental compilation */
     "target": "es2019",                             /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": ["es2019", "es2020.bigint"],             /* Specify library files to be included in the compilation. */
+    "lib": ["es2019", "es2020.bigint", "dom"],      /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */


### PR DESCRIPTION
Implement lazy cache per encoding.

There is a discussion to make about two things:
1. if we want to allow `.content` to be `string | Uint8Array` and only use Map if needed
2. TextDecoder is not capable of decoding all encodings, it throws on invalid encodings. We could implement a decode for the unsupported encodings, but I'm not sure if it's worth it.
