### PR TITLE
fix: overlayedFs `watchService` should watch changes in higherFs

### DIFF
--- a/packages/overlay/src/overlay-fs.ts
+++ b/packages/overlay/src/overlay-fs.ts
@@ -405,7 +405,7 @@ export function createOverlayFs(
     async watchPath(path, listener) {
       await lowerFs.watchService.watchPath(path, listener);
       const { resolvedLowerPath, resolvedUpperPath } = resolvePaths(path);
-      if (resolvedUpperPath) {
+      if (resolvedUpperPath !== undefined && upperFs.existsSync(resolvedUpperPath)) {
         let proxyListener: WatchEventListener | undefined;
 
         if (listener) {
@@ -430,7 +430,7 @@ export function createOverlayFs(
       await lowerFs.watchService.unwatchPath(path, listener);
       const { resolvedLowerPath, resolvedUpperPath } = resolvePaths(path);
 
-      if (resolvedUpperPath) {
+      if (resolvedUpperPath !== undefined && upperFs.existsSync(resolvedUpperPath)) {
         let proxyListener: WatchEventListener | undefined;
 
         if (listener) {

--- a/packages/overlay/test/overlay.spec.ts
+++ b/packages/overlay/test/overlay.spec.ts
@@ -167,7 +167,7 @@ describe('overlayFs watch service', function () {
     return { overlayFs, higherFs, lowerFs };
   }
 
-  it('watches change made with overlayFs in lowerFs', async () => {
+  it('global listener captures change made with overlayFs in lower file', async () => {
     const { overlayFs } = getFileSystems();
     const validator = new WatchEventsValidator(overlayFs.watchService);
 
@@ -177,7 +177,7 @@ describe('overlayFs watch service', function () {
     await validator.noMoreEvents();
   });
 
-  it('watches change made with higherFs', async () => {
+  it('global listener captures change made with higherFs', async () => {
     const { higherFs, overlayFs } = getFileSystems();
 
     const validator = new WatchEventsValidator(overlayFs.watchService);
@@ -188,7 +188,7 @@ describe('overlayFs watch service', function () {
     await validator.noMoreEvents();
   });
 
-  it('watches path, change made with higherFs', async () => {
+  it('path listener captures change made with higherFs', async () => {
     const { higherFs, overlayFs } = getFileSystems();
     const actualPathEvents: IWatchEvent[] = [];
     const listener1: WatchEventListener = (event) => {
@@ -203,7 +203,7 @@ describe('overlayFs watch service', function () {
     await validateEvents([{ path: higherFileInOverlayFs, stats }], actualPathEvents);
   });
 
-  it('watches path, receives change made with higherFs, no events sent after unwatchPath with listener1', async () => {
+  it('path listener captures change made with higherFs, no events captured after unwatchPath with listener1', async () => {
     const { higherFs, overlayFs } = getFileSystems();
     const actualPathEvents: IWatchEvent[] = [];
     const listener1: WatchEventListener = (event) => {
@@ -223,7 +223,7 @@ describe('overlayFs watch service', function () {
     await validateEvents([], actualPathEvents);
   });
 
-  it('watches path with multiple listeners, receives change made with higherFs, no events sent after unwatchPath with listener1', async () => {
+  it('multiple path listeners capture changes made with higherFs, no events captured after unwatchPath with listener1, next event captured only by listener2', async () => {
     const { higherFs, overlayFs } = getFileSystems();
     const actualPathEvents1: IWatchEvent[] = [];
     const listener1: WatchEventListener = (event) => {

--- a/packages/overlay/test/overlay.spec.ts
+++ b/packages/overlay/test/overlay.spec.ts
@@ -9,7 +9,6 @@ import {
 } from '@file-services/test-kit';
 import { createMemoryFs } from '@file-services/memory';
 import { createOverlayFs } from '@file-services/overlay';
-import { describe } from 'mocha';
 import type { IWatchEvent, WatchEventListener } from '@file-services/types';
 
 const sampleContent1 = `111`;
@@ -144,7 +143,7 @@ describe('overlay fs', () => {
 });
 
 describe('overlayFs watch service', function () {
-  this.timeout(6000000_000);
+  this.timeout(8_000);
   const baseDir = '/src';
   const folderInLower = `${baseDir}/folder-1`;
   const fileInLower = `${baseDir}/file1.js`;

--- a/packages/test-kit/src/watch-events-validator.ts
+++ b/packages/test-kit/src/watch-events-validator.ts
@@ -70,3 +70,18 @@ const simplifyEvent = ({ path, stats }: IWatchEvent) => ({
   path,
   stats: stats ? { birthtime: stats.birthtime.getTime(), mtime: stats.mtime.getTime() } : null,
 });
+
+export const validateEvents = async (
+  expectedEvents: IWatchEvent[],
+  actualEvents: IWatchEvent[],
+  options: IWatchEventValidatorOptions = { validateTimeout: 5000, noMoreEventsTimeout: 500 }
+): Promise<void> => {
+  await waitFor(
+    async () => {
+      const expected = expectedEvents.map(simplifyEvent);
+      const actual = actualEvents.map(simplifyEvent);
+      expect(actual).to.eql(expected);
+    },
+    { timeout: options.validateTimeout, delay: 100 }
+  );
+};


### PR DESCRIPTION
`createOverlayFs` combines `higherFs` and  and `lowerFs` using only `lowerFs`'s `watchService`. In a project where overlayedFs used, manipulation with `higherFs` will not emit events despite of content `overlayFs` being updated.
This change creates proxy `watchService` used in overlayedFs. This proxy does subscription in both file systems respecting mount point of higherFs.

Overlayed fs example
```
/src
      /dir1
             /fileL.js
      ***higher fs mounted on /src***
      /fileH.js

```
This subscription `overlayedFs.watchService.watchPath('/src/fileH.js', listener)` will subscribe to `higherFs.watchService` on path `/fileH.js` and lowerFs on `/src/fileH.js`. When change event will be emitted from higherFs - change event will convert back path to `/src/fileH.js`.



 