### PR TITLE
fix(node): clear pending events on unwatch

### DIFF
--- a/packages/node/src/watch-service.ts
+++ b/packages/node/src/watch-service.ts
@@ -75,12 +75,21 @@ export class NodeWatchService implements IWatchService {
         this.fsWatchers.delete(path);
       }
     }
+    const pendingEvent = this.pendingEvents.get(path);
+    if (pendingEvent) {
+      clearTimeout(pendingEvent.timerId);
+      this.pendingEvents.delete(path);
+    }
   }
 
   public async unwatchAllPaths(): Promise<void> {
     for (const watcher of this.fsWatchers.values()) {
       watcher.close();
     }
+    for (const { timerId } of this.pendingEvents.values()) {
+      clearTimeout(timerId);
+    }
+    this.pendingEvents.clear();
     this.fsWatchers.clear();
     this.watchedPaths.clear();
   }

--- a/packages/node/test/watch-service.nodespec.ts
+++ b/packages/node/test/watch-service.nodespec.ts
@@ -60,6 +60,20 @@ describe('Node Watch Service', function () {
       ]);
       await validator.noMoreEvents();
     });
+
+    it(`does not emit events after unwatching a path`, async () => {
+      await writeFile(testFilePath, SAMPLE_CONTENT);
+      await watchService.unwatchPath(testFilePath);
+
+      await validator.noMoreEvents();
+    });
+
+    it(`does not emit events after unwatching all path`, async () => {
+      await writeFile(testFilePath, SAMPLE_CONTENT);
+      await watchService.unwatchAllPaths();
+
+      await validator.noMoreEvents();
+    });
   });
 
   describe('watching directories', () => {


### PR DESCRIPTION
to avoid events being emitted after unwatching a specific path, or unwatching all paths