### PR TITLE
fix(resolve): track package.json files in dirs

### DIFF
--- a/packages/resolve/test/request-resolver.spec.ts
+++ b/packages/resolve/test/request-resolver.spec.ts
@@ -771,5 +771,35 @@ describe('request resolver', () => {
         '/src/index.js',
       ]);
     });
+
+    it('lists paths for package.json files it met inside packages', () => {
+      const fs = createMemoryFs({
+        'package.json': stringifyPackageJson({}),
+        node_modules: {
+          some_package: {
+            alt: {
+              'package.json': stringifyPackageJson({
+                name: 'some_package/alt',
+                main: '../actual.js',
+                private: true,
+              }),
+            },
+            'actual.js': EMPTY,
+          },
+        },
+      });
+      const resolveRequest = createRequestResolver({ fs });
+
+      const resolutionOutput = resolveRequest('/', 'some_package/alt');
+      expect(resolutionOutput).to.be.resolvedTo('/node_modules/some_package/actual.js');
+      expect(Array.from(resolutionOutput.visitedPaths)).to.eql([
+        '/package.json',
+        '/node_modules/some_package/alt',
+        '/node_modules/some_package/alt.js',
+        '/node_modules/some_package/alt.json',
+        '/node_modules/some_package/alt/package.json',
+        '/node_modules/some_package/actual.js',
+      ]);
+    });
   });
 });


### PR DESCRIPTION
previously, when requesting some_package/alt, only the root package.json was listed in visitedPaths. now it will list some_package/alt/package.json if it exists