### PR TITLE
fix(resolve): support "module" in "node" target

### DIFF
--- a/packages/resolve/src/request-resolver.ts
+++ b/packages/resolve/src/request-resolver.ts
@@ -249,12 +249,10 @@ export function createRequestResolver(options: IRequestResolverOptions): Request
   }
 
   function packageJsonTarget({ main, browser, module: moduleFieldValue }: PackageJson): string | undefined {
-    if (target === 'browser') {
-      if (typeof browser === 'string') {
-        return browser;
-      } else if (moduleField && typeof moduleFieldValue === 'string') {
-        return moduleFieldValue;
-      }
+    if (target === 'browser' && typeof browser === 'string') {
+      return browser;
+    } else if (moduleField && typeof moduleFieldValue === 'string') {
+      return moduleFieldValue;
     }
     return typeof main === 'string' ? main : undefined;
   }

--- a/packages/resolve/test/request-resolver.spec.ts
+++ b/packages/resolve/test/request-resolver.spec.ts
@@ -418,6 +418,19 @@ describe('request resolver', () => {
       expect(resolveRequest('/', './lodash')).to.be.resolvedTo('/lodash/entry.js');
     });
 
+    it('prefers "module" over "main" when "moduleField" is set to true and "target" is "node"', () => {
+      const fs = createMemoryFs({
+        lodash: {
+          'package.json': stringifyPackageJson({ main: 'entry.js', module: './browser.js' }),
+          'entry.js': EMPTY,
+          'browser.js': EMPTY,
+        },
+      });
+      const resolveRequest = createRequestResolver({ fs, moduleField: true, target: 'node' });
+
+      expect(resolveRequest('/', './lodash')).to.be.resolvedTo('/lodash/browser.js');
+    });
+
     it('prefers "main" over "module" when "moduleField" is set to false', () => {
       const fs = createMemoryFs({
         lodash: {


### PR DESCRIPTION
previously only worked in `target === "browser"`