### PR TITLE
feat(commonjs): nicer evaluation error message

### DIFF
--- a/packages/commonjs/src/base-cjs-module-system.ts
+++ b/packages/commonjs/src/base-cjs-module-system.ts
@@ -131,13 +131,7 @@ export function createBaseCjsModuleSystem(options: IBaseModuleSystemOptions): IC
       moduleFn(...Object.values(moduleBuiltins));
     } catch (e) {
       requireCache.delete(filePath);
-
-      // switch to Error.cause once more places support it
-      if (e instanceof Error && !(e as { filePath?: string }).filePath) {
-        (e as { filePath?: string }).filePath = filePath;
-      }
-
-      throw e;
+      throw new Error(`Failed evaluating ${filePath}`, { cause: e });
     }
 
     return newModule;

--- a/packages/commonjs/test/tsconfig.json
+++ b/packages/commonjs/test/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../dist/test",
-    "lib": ["es2019", "es2020.bigint", "dom"],
     "types": ["mocha", "node"]
   },
   "references": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2021",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["es2021"],                                   /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["es2022"],                                   /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
uses Error.cause to expose original reason it failed, while the error contains filePath being evaluated