### PR TITLE
fix(resolve): avoid re-matching subpath patterns

### DIFF
--- a/packages/resolve/src/request-resolver.ts
+++ b/packages/resolve/src/request-resolver.ts
@@ -383,7 +383,7 @@ function matchSubpathPatterns(exportedSubpaths: PackageJson.ExportConditions, in
     }
     if (patternValue === null) {
       return undefined;
-    } else if (typeof patternValue === 'string') {
+    } else if (matchedPattern === undefined && typeof patternValue === 'string') {
       const innerPathStarValue = innerPath.slice(keyPrefix.length, innerPath.length - keySuffix.length);
       const valueStarIdx = patternValue.indexOf('*');
       if (valueStarIdx === -1 || patternValue.indexOf('*', valueStarIdx + 1) !== -1) {

--- a/packages/resolve/test/request-resolver.spec.ts
+++ b/packages/resolve/test/request-resolver.spec.ts
@@ -849,6 +849,22 @@ describe('request resolver', () => {
 
         expect(resolveRequest('/', 'tslib/tslib.js')).to.be.resolvedTo('/node_modules/tslib/tslib.js');
       });
+
+      it('picks first match, even if there are several that match', () => {
+        const fs = createMemoryFs({
+          node_modules: {
+            tslib: {
+              'package.json': stringifyPackageJson({ exports: { './dist/*': './dist/*.js', './*': './*' } }),
+              dist: {
+                'file.js': EMPTY,
+              },
+            },
+          },
+        });
+        const resolveRequest = createRequestResolver({ fs });
+
+        expect(resolveRequest('/', 'tslib/dist/file')).to.be.resolvedTo('/node_modules/tslib/dist/file.js');
+      });
     });
 
     describe('no cjs resolution leakage', () => {


### PR DESCRIPTION
when resolver finds a pattern match, we keep going over the "exports" to see if we can find `null` (for explicit file exclusion). if we do find another matching key, we should not also try to re-match string values.