### PR TITLE
fix(resolve): consider other fields if no target

### DIFF
--- a/packages/resolve/src/types.ts
+++ b/packages/resolve/src/types.ts
@@ -96,10 +96,12 @@ export interface IResolutionFileSystem {
 }
 
 export interface IResolvedPackageJson {
-  name?: string;
   filePath: string;
   directoryPath: string;
-  mainPath?: string;
+  name?: string;
+  main?: string;
+  module?: string;
+  browser?: string;
   browserMappings?: {
     [from: string]: string | false;
   };


### PR DESCRIPTION
the resolver tries "browser" -> "module" -> "main".

when "browser" or "module" pointed to a non-existing target, it failed to try any of the other fields.

Now it does, matching the behavior to that of enhanced-resolve (used by webpack).