### PR TITLE
fix(node): use cwd for case-sensitivity check

### DIFF
--- a/packages/node/src/node-fs.ts
+++ b/packages/node/src/node-fs.ts
@@ -1,13 +1,13 @@
-import fs from 'fs';
-import path from 'path';
-import { chdir, cwd } from 'process';
-import { promisify } from 'util';
+import fs from 'node:fs';
+import path from 'node:path';
+import { chdir, cwd } from 'node:process';
+import { promisify } from 'node:util';
 
-import { createFileSystem } from '@file-services/utils';
 import type { IBaseFileSystem, IFileSystem, IFileSystemPath } from '@file-services/types';
-import { NodeWatchService, INodeWatchServiceOptions } from './watch-service';
+import { createFileSystem } from '@file-services/utils';
+import { INodeWatchServiceOptions, NodeWatchService } from './watch-service';
 
-const caseSensitive = !fs.existsSync(__filename.toUpperCase());
+const caseSensitive = !fs.existsSync(cwd().toUpperCase());
 const fsPromisesExists = promisify(fs.exists);
 
 export interface ICreateNodeFsOptions {

--- a/packages/node/src/watch-service.ts
+++ b/packages/node/src/watch-service.ts
@@ -1,7 +1,8 @@
-import { join } from 'path';
-import { promises as fsPromises, watch, FSWatcher } from 'fs';
-import { once } from 'events';
-import type { IWatchService, WatchEventListener, IWatchEvent, IFileSystemStats } from '@file-services/types';
+import { once } from 'node:events';
+import { FSWatcher, promises as fsPromises, watch } from 'node:fs';
+import { join } from 'node:path';
+
+import type { IFileSystemStats, IWatchEvent, IWatchService, WatchEventListener } from '@file-services/types';
 import { SetMultiMap } from '@file-services/utils';
 
 const { stat } = fsPromises;


### PR DESCRIPTION
- to fix mjs target not working due to accessing __filename
- import from "node:<lib>" for clarity