### PR TITLE
feat(resolve): subpath patterns with multiple replacement

### DIFF
--- a/packages/resolve/src/request-resolver.ts
+++ b/packages/resolve/src/request-resolver.ts
@@ -519,12 +519,10 @@ function* matchSubpathPatterns(
       }
       const innerPathStarValue = innerPath.slice(keyPrefix.length, innerPath.length - keySuffix.length);
       const valueStarIdx = valueToMatch.indexOf('*');
-      if (valueStarIdx === -1 || valueToMatch.indexOf('*', valueStarIdx + 1) !== -1) {
+      if (valueStarIdx === -1) {
         continue;
       }
-      const valuePrefix = valueToMatch.slice(0, valueStarIdx);
-      const valueSuffix = valueToMatch.slice(valueStarIdx + 1);
-      matchedValues.push(valuePrefix + innerPathStarValue + valueSuffix);
+      matchedValues.push(valueToMatch.replace(/\*/g, innerPathStarValue));
     }
   }
   yield* matchedValues;

--- a/packages/resolve/test/request-resolver.spec.ts
+++ b/packages/resolve/test/request-resolver.spec.ts
@@ -863,6 +863,13 @@ describe('request resolver', () => {
                   a: {
                     'a.js': EMPTY,
                   },
+                  b: {
+                    b: {
+                      b: {
+                        'b.js': EMPTY,
+                      },
+                    },
+                  },
                 },
               },
             },
@@ -872,6 +879,9 @@ describe('request resolver', () => {
 
         expect(resolveRequest('/', 'lodash/features/a.js')).to.be.resolvedTo(
           '/node_modules/lodash/src/features/a/a.js'
+        );
+        expect(resolveRequest('/', 'lodash/features/b/b.js')).to.be.resolvedTo(
+          '/node_modules/lodash/src/features/b/b/b/b.js'
         );
       });
 

--- a/packages/resolve/test/request-resolver.spec.ts
+++ b/packages/resolve/test/request-resolver.spec.ts
@@ -849,6 +849,32 @@ describe('request resolver', () => {
         );
       });
 
+      it('supports pattern matching with multiple replacements for files', () => {
+        const fs = createMemoryFs({
+          node_modules: {
+            lodash: {
+              'package.json': stringifyPackageJson({
+                exports: {
+                  './features/*.js': './src/features/*/*.js',
+                },
+              }),
+              src: {
+                features: {
+                  a: {
+                    'a.js': EMPTY,
+                  },
+                },
+              },
+            },
+          },
+        });
+        const resolveRequest = createRequestResolver({ fs });
+
+        expect(resolveRequest('/', 'lodash/features/a.js')).to.be.resolvedTo(
+          '/node_modules/lodash/src/features/a/a.js'
+        );
+      });
+
       it('supports exclusion of subfolders', () => {
         const fs = createMemoryFs({
           node_modules: {


### PR DESCRIPTION
This PR enhances the handling of `package.json exports` by aligning with the specification that [states](https://nodejs.org/api/packages.html#subpath-patterns): 

> All instances of * on the right-hand side will then be replaced with this value, including if it contains any / separators.

Prior to this update, the resolver was limited to recognizing subpath patterns that map to only a single asterisk (*) on the right-hand side. With the new changes, the resolver can now process patterns containing multiple asterisks.