### PR TITLE
feat(commonjs)!: better evaluation-time error messages

### DIFF
--- a/packages/commonjs/test/cjs-module-system.spec.ts
+++ b/packages/commonjs/test/cjs-module-system.spec.ts
@@ -295,17 +295,9 @@ module.exports = global;`,
     });
     const { requireModule } = createCjsModuleSystem({ fs });
 
-    expect(() => requireModule(sampleFilePath)).to.throw("Thanos is coming!");
-    let e: unknown;
-    try {
-      requireModule(sampleFilePath);
-    } catch (error) {
-      e = error;
-    }
-    expect(e).to.haveOwnProperty("filePath", sampleFilePath);
+    expect(() => requireModule(sampleFilePath)).to.throw(`Failed evaluating: ${sampleFilePath} -> Thanos is coming!`);
 
     fs.writeFileSync(sampleFilePath, `module.exports = 1`);
-
     expect(requireModule(sampleFilePath)).to.equal(1);
   });
 
@@ -316,7 +308,7 @@ module.exports = global;`,
     });
     const { requireModule } = createCjsModuleSystem({ fs });
 
-    expect(() => requireModule(sampleJsonPath)).to.throw();
+    expect(() => requireModule(sampleJsonPath)).to.throw(`Failed evaluating: ${sampleJsonPath}`);
 
     fs.writeFileSync(sampleJsonPath, `{ "name": "test" }`);
 


### PR DESCRIPTION
- inject file path chain into the prefix of the error message
- ensure .json file evaluation errors have file path as well
- avoid injecting sourceURL comment to allow support for full sourcemaps