### PR TITLE
feat: add includeSymbolicLinks param to findFilesSync

### DIFF
--- a/packages/test-kit/src/sync-fs-contract.ts
+++ b/packages/test-kit/src/sync-fs-contract.ts
@@ -224,12 +224,19 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
           [fileName]: "",
           folder1: {},
           folder2: {},
-          ignoredFolder: {},
+          ignoredFolder1: {},
         });
 
-        fs.symlinkSync(fs.join(directoryPath, fileName), fs.join(directoryPath, "folder1", "link"));
-        fs.symlinkSync(fs.join(directoryPath, fileName), fs.join(directoryPath, "folder2", "ignored-link"));
-        fs.symlinkSync(fs.join(directoryPath, fileName), fs.join(directoryPath, "ignoredFolder", "link"));
+        // /folder1/link => /fileName
+        fs.symlinkSync(fs.join(directoryPath, fileName), fs.join(directoryPath, "folder1", "link"), "junction");
+        // /folder2/ignored-link => /fileName
+        fs.symlinkSync(fs.join(directoryPath, fileName), fs.join(directoryPath, "folder2", "ignored-link"), "junction");
+        // /ignoredFolder1/link => /fileName
+        fs.symlinkSync(fs.join(directoryPath, fileName), fs.join(directoryPath, "ignoredFolder1", "link"), "junction");
+        // /folder3 => /folder1
+        fs.symlinkSync(fs.join(directoryPath, "folder1"), fs.join(directoryPath, "folder3"), "junction");
+        // /ignoredFolder2 => /folder1
+        fs.symlinkSync(fs.join(directoryPath, "folder1"), fs.join(directoryPath, "ignoredFolder2"), "junction");
 
         expect(fs.findFilesSync(directoryPath)).to.eql([fs.join(directoryPath, fileName)]);
 
@@ -237,9 +244,13 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
           fs.findFilesSync(directoryPath, {
             includeSymbolicLinks: true,
             filterFile: (desc) => desc.name !== "ignored-link",
-            filterDirectory: (desc) => desc.name !== "ignoredFolder",
+            filterDirectory: (desc) => desc.name !== "ignoredFolder1" && desc.name !== "ignoredFolder2",
           }),
-        ).to.eql([fs.join(directoryPath, fileName), fs.join(directoryPath, "folder1", "link")]);
+        ).to.eql([
+          fs.join(directoryPath, fileName),
+          fs.join(directoryPath, "folder1", "link"),
+          fs.join(directoryPath, "folder3", "link"),
+        ]);
       });
     });
 

--- a/packages/test-kit/src/sync-fs-contract.ts
+++ b/packages/test-kit/src/sync-fs-contract.ts
@@ -248,8 +248,11 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
           }),
         ).to.eql([
           fs.join(directoryPath, fileName),
-          fs.join(directoryPath, "folder1", "link"),
-          fs.join(directoryPath, "folder3", "link"),
+          fs.join(directoryPath, "folder1", "link"), // /folder1/link is included because of includeSymbolicLinks
+          // /folder2/ignored-link is filtered out by filterFile
+          fs.join(directoryPath, "folder3", "link"), // /folder3/link is included because folder3 is a link to folder1
+          // /ignoredFolder1/link is filtered out by filterDirectory
+          // /ignoredFolder2 is filtered out by filterDirectory
         ]);
       });
     });

--- a/packages/test-kit/src/sync-fs-contract.ts
+++ b/packages/test-kit/src/sync-fs-contract.ts
@@ -215,6 +215,32 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
           fs.join(directoryPath, "folder2", anotherFileName),
         ]);
       });
+
+      it("respects includeSymbolicLinks option", () => {
+        const { fs, tempDirectoryPath } = testInput;
+        const directoryPath = fs.join(tempDirectoryPath, "dir");
+
+        fs.populateDirectorySync(directoryPath, {
+          [fileName]: "",
+          folder1: {},
+          folder2: {},
+          ignoredFolder: {},
+        });
+
+        fs.symlinkSync(fs.join(directoryPath, fileName), fs.join(directoryPath, "folder1", "link"));
+        fs.symlinkSync(fs.join(directoryPath, fileName), fs.join(directoryPath, "folder2", "ignored-link"));
+        fs.symlinkSync(fs.join(directoryPath, fileName), fs.join(directoryPath, "ignoredFolder", "link"));
+
+        expect(fs.findFilesSync(directoryPath)).to.eql([fs.join(directoryPath, fileName)]);
+
+        expect(
+          fs.findFilesSync(directoryPath, {
+            includeSymbolicLinks: true,
+            filterFile: (desc) => desc.name !== "ignored-link",
+            filterDirectory: (desc) => desc.name !== "ignoredFolder",
+          }),
+        ).to.eql([fs.join(directoryPath, fileName), fs.join(directoryPath, "folder1", "link")]);
+      });
     });
 
     describe("findClosestFileSync", () => {

--- a/packages/types/src/common-fs-types.ts
+++ b/packages/types/src/common-fs-types.ts
@@ -142,6 +142,13 @@ export interface IWalkOptions {
    * @default true returned for all directories.
    */
   filterDirectory?(pathDesc: IFileSystemDescriptor): boolean;
+
+  /**
+   * Optional parameter specifying whether files symbolic links should be included in the result.
+   *
+   * @default false
+   */
+  includeSymbolicLinks?: boolean;
 }
 
 export interface RmOptions {

--- a/packages/utils/src/create-extended-api.ts
+++ b/packages/utils/src/create-extended-api.ts
@@ -119,8 +119,13 @@ export function createExtendedSyncActions(baseFs: IBaseFileSystemSync): IFileSys
         filePaths.push(nodePath);
       } else if (item.isDirectory() && filterDirectory(nodeDesc)) {
         findFilesSync(nodePath, options, filePaths);
-      } else if (item.isSymbolicLink() && options.includeSymbolicLinks && filterFile(nodeDesc)) {
-        filePaths.push(nodePath);
+      } else if (item.isSymbolicLink() && options.includeSymbolicLinks) {
+        const stat = statSync(nodePath);
+        if (stat.isFile() && filterFile(nodeDesc)) {
+          filePaths.push(nodePath);
+        } else if (stat.isDirectory() && filterDirectory(nodeDesc)) {
+          findFilesSync(nodePath, options, filePaths);
+        }
       }
     }
 

--- a/packages/utils/src/create-extended-api.ts
+++ b/packages/utils/src/create-extended-api.ts
@@ -133,10 +133,10 @@ export function createExtendedSyncActions(baseFs: IBaseFileSystemSync): IFileSys
       } else if (item.isSymbolicLink() && options.includeSymbolicLinks) {
         const linkTarget = readlinkSync(nodePath);
         if (existsSync(linkTarget)) {
-          const stat = statSync(linkTarget);
-          if (stat.isFile() && filterFile(nodeDesc)) {
+          const stats = statSync(linkTarget);
+          if (stats.isFile() && filterFile(nodeDesc)) {
             filePaths.push(nodePath);
-          } else if (stat.isDirectory() && filterDirectory(nodeDesc)) {
+          } else if (stats.isDirectory() && filterDirectory(nodeDesc)) {
             findFilesSync(nodePath, options, filePaths);
           }
         }
@@ -224,7 +224,7 @@ export function createExtendedFileSystemPromiseActions(
     dirname,
     resolve,
     join,
-    promises: { stat, mkdir, writeFile, readdir, readFile, copyFile },
+    promises: { stat, mkdir, writeFile, readdir, readFile, readlink, copyFile, exists },
   } = baseFs;
 
   async function fileExists(filePath: string, statFn = stat): Promise<boolean> {
@@ -319,6 +319,16 @@ export function createExtendedFileSystemPromiseActions(
         filePaths.push(nodePath);
       } else if (item.isDirectory() && filterDirectory(nodeDesc)) {
         await findFiles(nodePath, options, filePaths);
+      } else if (item.isSymbolicLink() && options.includeSymbolicLinks) {
+        const linkTarget = await readlink(nodePath);
+        if (await exists(linkTarget)) {
+          const stats = await stat(linkTarget);
+          if (stats.isFile() && filterFile(nodeDesc)) {
+            filePaths.push(nodePath);
+          } else if (stats.isDirectory() && filterDirectory(nodeDesc)) {
+            await findFiles(nodePath, options, filePaths);
+          }
+        }
       }
     }
 

--- a/packages/utils/src/create-extended-api.ts
+++ b/packages/utils/src/create-extended-api.ts
@@ -119,6 +119,8 @@ export function createExtendedSyncActions(baseFs: IBaseFileSystemSync): IFileSys
         filePaths.push(nodePath);
       } else if (item.isDirectory() && filterDirectory(nodeDesc)) {
         findFilesSync(nodePath, options, filePaths);
+      } else if (item.isSymbolicLink() && options.includeSymbolicLinks && filterFile(nodeDesc)) {
+        filePaths.push(nodePath);
       }
     }
 


### PR DESCRIPTION
Add `includeSymbolicLinks` parameter to `findFilesSync` function that allows include symbolic links in a search results