### PR TITLE
feat: introduce native fs.watch

### DIFF
--- a/packages/node/test/node-fs.nodespec.ts
+++ b/packages/node/test/node-fs.nodespec.ts
@@ -28,7 +28,8 @@ describe("Node File System Implementation", function () {
   // async contract passes, which is really what we care about.
   // avoid introducing more and more workarounds to support mac watcher being ready synchronously.
   if (platform() !== "darwin") {
-    syncBaseFsContract(testProvider);
+    const supportsRecursiveWatch = parseInt(process.versions.node, 10) >= 20 || platform() !== "linux";
+    syncBaseFsContract(testProvider, supportsRecursiveWatch);
   }
   asyncBaseFsContract(testProvider);
 

--- a/packages/types/src/base-api-sync.ts
+++ b/packages/types/src/base-api-sync.ts
@@ -1,10 +1,12 @@
 import type {
   BufferEncoding,
+  FSWatcher,
   IDirectoryEntry,
   IFileSystemStats,
   ReadFileOptions,
   RmOptions,
   StatSyncOptions,
+  WatchOptions,
   WriteFileOptions,
 } from "./common-fs-types";
 import type { IFileSystemPath } from "./path";
@@ -135,4 +137,7 @@ export interface IBaseFileSystemSyncActions {
    * Changes the permissions of a file.
    */
   chmodSync(path: string, mode: number | string): void;
+
+  /** Watch a file or a directory (optionally recursively). */
+  watch(path: string, options?: WatchOptions): FSWatcher;
 }

--- a/packages/types/src/common-fs-types.ts
+++ b/packages/types/src/common-fs-types.ts
@@ -157,3 +157,28 @@ export interface RmOptions {
    */
   recursive?: boolean | undefined;
 }
+
+export interface WatchOptions {
+  /**
+   * When watching a directory, also watch deeply nested children.
+   * @default false
+   */
+  recursive?: boolean;
+}
+
+export type WatchChangeEventListener = (eventType: "change" | "rename", relativePath: string) => void;
+
+export interface FSWatcher {
+  /**
+   * Stop watching for changes on the given `FSWatcher`. Once stopped, the `FSWatcher` object is no longer usable.
+   */
+  close(): void;
+
+  on(event: "change", listener: WatchChangeEventListener): this;
+  on(event: "close", listener: () => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+
+  off(event: "change", listener: WatchChangeEventListener): this;
+  off(event: "close", listener: () => void): this;
+  off(event: "error", listener: (error: Error) => void): this;
+}


### PR DESCRIPTION
- implement `watch()` for memory fs
- expose native node one, as it is now supported on linux as well