### PR TITLE
fix(watch-service): remove watcher when it gets closed due to directory removal

### DIFF
--- a/packages/node/src/watch-service.ts
+++ b/packages/node/src/watch-service.ts
@@ -211,6 +211,7 @@ export class NodeWatchService implements IWatchService {
     const watcher = this.fsWatchers.get(path);
     if (watcher) {
       watcher.close();
+      this.fsWatchers.delete(path);
     }
   }
 

--- a/packages/node/test/watch-service.nodespec.ts
+++ b/packages/node/test/watch-service.nodespec.ts
@@ -97,6 +97,12 @@ describe("Node Watch Service", function () {
       await validator.validateEvents([{ path: testDirectoryPath, stats: null }]);
       await validator.noMoreEvents();
     });
+
+    it("unwatchAllPaths can be invoked immediately after watched dir removal", async () => {
+      await watchService.watchPath(testDirectoryPath);
+      await rmdir(testDirectoryPath);
+      await watchService.unwatchAllPaths();
+    });
   });
 
   describe("mixing watch of directories and files", () => {

--- a/packages/node/test/watch-service.nodespec.ts
+++ b/packages/node/test/watch-service.nodespec.ts
@@ -98,7 +98,7 @@ describe("Node Watch Service", function () {
       await validator.noMoreEvents();
     });
 
-    it("unwatchAllPaths can be invoked immediately after watched dir removal", async () => {
+    it("unwatchAllPaths does not get stuck when invoked immediately after watched dir is removed", async () => {
       await watchService.watchPath(testDirectoryPath);
       await rmdir(testDirectoryPath);
       await watchService.unwatchAllPaths();


### PR DESCRIPTION
Fixes #1186

On Windows deleting watched directory is firing event `error` which is caught by `NodeWatchService.ensureWatcher`:
```
      directoryWatcher.once("error", (e) => {
        this.onWatchError(e, path);
      });
```

this in turn causes 2 effects:
1. `watcher.close();` in the `onWatchError`
2. debounced (by `onPathEvent`) `this.fsWatchers.delete(path);`  in the `emitEvent` method.

If `unwatchAllPaths` was invoked between these 2 effects we would enter a state when `unwatchAllPaths` can't finish.
This happened due to 
1. `unwatchAllPaths` assumes that all `this.fsWatchers` are not closed
2. `unwatchAllPaths` invokes `close` on each watcher and waits for the `close` event on all of watchers
But this can't work because  `watcher.close();` was called in the `onWatchError`, so we are left with a method which can't end.

The proposed fix is to remove watcher  from `this.fsWatchers` inside the `onWatchError` immediately after watcher is closed.