### PR TITLE
Testing workflow with Node 22 and 20 only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 20, 18]
+        node-version: [22, 20]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I have some failures with Node 18, so I'm dropping it and trying with 20 & 22 only.