### PR TITLE
fix: async watch in recursive watcher Linux shim

### DIFF
--- a/packages/node/src/recursive-fs-watcher.ts
+++ b/packages/node/src/recursive-fs-watcher.ts
@@ -21,7 +21,9 @@ export class RecursiveFSWatcher extends EventEmitter<WatcherEvents> {
     }
     this.rootDirectoryPath = rootDirectoryPath;
     this.options = { ...options, recursive: false };
-    this.#watchDirectoryDeep(rootDirectoryPath);
+    setImmediate(() => {
+      this.#watchDirectoryDeep(rootDirectoryPath);
+    });
   }
 
   close() {


### PR DESCRIPTION
otherwise, it will throw and crash process when recursive watch emits an error event during class construction, and no 'error' handler was registered yet.