### PR TITLE
ci: test on Node 23 as well

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 20]
+        node-version: [23, 22, 20]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
preparing for Node 24, once it releases. they are still working on v8 13.4 integration