### PR TITLE
feat: support stats size

### DIFF
--- a/packages/memory/src/memory-fs.ts
+++ b/packages/memory/src/memory-fs.ts
@@ -178,12 +178,14 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
       if (existingNode.type === "dir") {
         throw createFsError(resolvedPath, FsErrorCodes.PATH_IS_DIRECTORY, "EISDIR");
       }
+      const encodedContent =
+        typeof fileContent === "string" ? textEncoder.encode(fileContent) : new Uint8Array(fileContent);
       existingNode.entry = {
         ...existingNode.entry,
         mtime: new Date(),
-        size: typeof fileContent === "string" ? textEncoder.encode(fileContent).byteLength : fileContent.byteLength,
+        size: encodedContent.byteLength,
       };
-      existingNode.contents = typeof fileContent === "string" ? fileContent : new Uint8Array(fileContent);
+      existingNode.contents = encodedContent;
       emitChangeEvent("change", resolvedPath);
     } else {
       const parentPath = posixPath.dirname(resolvedPath);
@@ -195,6 +197,8 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
 
       const fileName = posixPath.basename(resolvedPath);
       const currentDate = new Date();
+      const encodedContent =
+        typeof fileContent === "string" ? textEncoder.encode(fileContent) : new Uint8Array(fileContent);
       const newFileNode: IFsMemFileNode = {
         type: "file",
         entry: {
@@ -202,12 +206,12 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
           birthtime: currentDate,
           mtime: currentDate,
           ctime: currentDate,
-          size: typeof fileContent === "string" ? textEncoder.encode(fileContent).byteLength : fileContent.byteLength,
+          size: encodedContent.byteLength,
           isFile: returnsTrue,
           isDirectory: returnsFalse,
           isSymbolicLink: returnsFalse,
         },
-        contents: typeof fileContent === "string" ? fileContent : new Uint8Array(fileContent),
+        contents: encodedContent,
       };
       parentNode.contents.set(fileName, newFileNode);
       emitChangeEvent("rename", resolvedPath);

--- a/packages/memory/src/memory-fs.ts
+++ b/packages/memory/src/memory-fs.ts
@@ -178,7 +178,11 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
       if (existingNode.type === "dir") {
         throw createFsError(resolvedPath, FsErrorCodes.PATH_IS_DIRECTORY, "EISDIR");
       }
-      existingNode.entry = { ...existingNode.entry, mtime: new Date() };
+      existingNode.entry = {
+        ...existingNode.entry,
+        mtime: new Date(),
+        size: typeof fileContent === "string" ? textEncoder.encode(fileContent).byteLength : fileContent.byteLength,
+      };
       existingNode.contents = typeof fileContent === "string" ? fileContent : new Uint8Array(fileContent);
       emitChangeEvent("change", resolvedPath);
     } else {
@@ -198,6 +202,7 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
           birthtime: currentDate,
           mtime: currentDate,
           ctime: currentDate,
+          size: typeof fileContent === "string" ? textEncoder.encode(fileContent).byteLength : fileContent.byteLength,
           isFile: returnsTrue,
           isDirectory: returnsFalse,
           isSymbolicLink: returnsFalse,
@@ -543,6 +548,7 @@ export function createBaseMemoryFsSync(): IBaseMemFileSystemSync {
         birthtime: currentDate,
         mtime: currentDate,
         ctime: currentDate,
+        size: textEncoder.encode(target).byteLength,
         isFile: returnsFalse,
         isDirectory: returnsFalse,
         isSymbolicLink: returnsTrue,
@@ -626,6 +632,7 @@ function createMemDirectory(name: string): IFsMemDirectoryNode {
       birthtime: currentDate,
       mtime: currentDate,
       ctime: currentDate,
+      size: 0,
       isFile: returnsFalse,
       isDirectory: returnsTrue,
       isSymbolicLink: returnsFalse,

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -30,7 +30,7 @@ export type IFsMemNodeType = IFsMemFileNode | IFsMemDirectoryNode | IFsMemSymlin
 
 export interface IFsMemFileNode extends IFsMemNode {
   type: "file";
-  contents: string | Uint8Array;
+  contents: Uint8Array;
 }
 
 export interface IFsMemDirectoryNode extends IFsMemNode {

--- a/packages/memory/test/memory-fs.spec.ts
+++ b/packages/memory/test/memory-fs.spec.ts
@@ -37,9 +37,9 @@ describe("In-memory File System Implementation", () => {
     it("reports correct byte sizes for files, directories, and symlinks", () => {
       const encoder = new TextEncoder();
 
-      const content = "€€€"; // 3 chars, 9 UTF-8 bytes
+      const content = "🚀🚀🚀"; // 3 chars, 12 UTF-8 bytes
       const fileFs = createMemoryFs({ "/file": content });
-      expect(fileFs.statSync("/file").size, "multi-byte UTF-8 string").to.equal(9);
+      expect(fileFs.statSync("/file").size, "multi-byte UTF-8 string").to.equal(12);
 
       const dirFs = createMemoryFs({ "/dir": {} });
       expect(dirFs.statSync("/dir").size, "directory").to.equal(0);

--- a/packages/memory/test/memory-fs.spec.ts
+++ b/packages/memory/test/memory-fs.spec.ts
@@ -33,6 +33,26 @@ describe("In-memory File System Implementation", () => {
     });
   });
 
+  describe("stat size", () => {
+    it("reports correct byte sizes for files, directories, and symlinks", () => {
+      const encoder = new TextEncoder();
+
+      const content = "€€€"; // 3 chars, 9 UTF-8 bytes
+      const fileFs = createMemoryFs({ "/file": content });
+      expect(fileFs.statSync("/file").size, "multi-byte UTF-8 string").to.equal(9);
+
+      const dirFs = createMemoryFs({ "/dir": {} });
+      expect(dirFs.statSync("/dir").size, "directory").to.equal(0);
+
+      const targetPath = "/some/target/path";
+      const symlinkFs = createMemoryFs();
+      symlinkFs.symlinkSync(targetPath, "/link");
+      expect(symlinkFs.lstatSync("/link").size, "symlink target byte length").to.equal(
+        encoder.encode(targetPath).byteLength,
+      );
+    });
+  });
+
   describe("creating directories", () => {
     it("fails creating the root", async () => {
       const fs = createMemoryFs();

--- a/packages/test-kit/src/async-base-fs-contract.ts
+++ b/packages/test-kit/src/async-base-fs-contract.ts
@@ -111,6 +111,31 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
     });
 
+    it("stat size reflects the byte size of written content", async () => {
+      const {
+        tempDirectoryPath,
+        fs: {
+          join,
+          promises: { stat, writeFile },
+        },
+      } = testInput;
+      const filePath = join(tempDirectoryPath, "file");
+      const binaryContent = new Uint8Array([1, 2, 3, 4, 5]);
+      const encoder = new TextEncoder();
+
+      await writeFile(filePath, SAMPLE_CONTENT);
+      expect((await stat(filePath)).size, "string content").to.equal(encoder.encode(SAMPLE_CONTENT).byteLength);
+
+      await writeFile(filePath, DIFFERENT_CONTENT);
+      expect((await stat(filePath)).size, "overwritten content").to.equal(encoder.encode(DIFFERENT_CONTENT).byteLength);
+
+      await writeFile(filePath, binaryContent);
+      expect((await stat(filePath)).size, "binary content").to.equal(binaryContent.byteLength);
+
+      // directory size is implementation-defined
+      expect((await stat(tempDirectoryPath)).size, "directory").to.be.a("number");
+    });
+
     describe("reading files", () => {
       it("can read the contents of a file", async () => {
         const {

--- a/packages/test-kit/src/async-base-fs-contract.ts
+++ b/packages/test-kit/src/async-base-fs-contract.ts
@@ -120,6 +120,8 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         },
       } = testInput;
       const filePath = join(tempDirectoryPath, "file");
+      const SAMPLE_CONTENT = "🚀";
+      const DIFFERENT_CONTENT = "🚀🚀";
       const binaryContent = new Uint8Array([1, 2, 3, 4, 5]);
       const encoder = new TextEncoder();
 

--- a/packages/test-kit/src/sync-base-fs-contract.ts
+++ b/packages/test-kit/src/sync-base-fs-contract.ts
@@ -83,6 +83,25 @@ export function syncBaseFsContract(
       });
     });
 
+    it("stat size reflects the byte size of written content", () => {
+      const { fs, tempDirectoryPath } = testInput;
+      const filePath = fs.join(tempDirectoryPath, "file");
+      const binaryContent = new Uint8Array([1, 2, 3, 4, 5]);
+      const encoder = new TextEncoder();
+
+      fs.writeFileSync(filePath, SAMPLE_CONTENT);
+      expect(fs.statSync(filePath).size, "string content").to.equal(encoder.encode(SAMPLE_CONTENT).byteLength);
+
+      fs.writeFileSync(filePath, DIFFERENT_CONTENT);
+      expect(fs.statSync(filePath).size, "overwritten content").to.equal(encoder.encode(DIFFERENT_CONTENT).byteLength);
+
+      fs.writeFileSync(filePath, binaryContent);
+      expect(fs.statSync(filePath).size, "binary content").to.equal(binaryContent.byteLength);
+
+      // directory size is implementation-defined; only assert it is a number
+      expect(fs.statSync(tempDirectoryPath).size, "directory").to.be.a("number");
+    });
+
     describe("reading files", () => {
       it("can read the contents of a file", () => {
         const { fs, tempDirectoryPath } = testInput;

--- a/packages/test-kit/src/sync-base-fs-contract.ts
+++ b/packages/test-kit/src/sync-base-fs-contract.ts
@@ -86,6 +86,8 @@ export function syncBaseFsContract(
     it("stat size reflects the byte size of written content", () => {
       const { fs, tempDirectoryPath } = testInput;
       const filePath = fs.join(tempDirectoryPath, "file");
+      const SAMPLE_CONTENT = "🚀";
+      const DIFFERENT_CONTENT = "🚀🚀";
       const binaryContent = new Uint8Array([1, 2, 3, 4, 5]);
       const encoder = new TextEncoder();
 

--- a/packages/types/src/common-fs-types.ts
+++ b/packages/types/src/common-fs-types.ts
@@ -94,6 +94,13 @@ export interface IFileSystemStats {
   mtime: Date;
 
   /**
+   * Size in bytes. For files, this is the file content size.
+   * For symbolic links, this is the byte length of the target path.
+   * For directories, this is implementation-defined.
+   */
+  size: number;
+
+  /**
    * is the path pointing to a file
    */
   isFile(): boolean;


### PR DESCRIPTION
Adds `"size: number"` to `IFileSystemStats` and implements it in the memory filesystem.

I thought about keeping the memory filesystem lighter by having size default to 0 and only be computed when an opt-in flag (e.g., `"{ statsSize: true }"`) is passed to `createMemoryFs`.

