### PR TITLE
test: use disposable test providers

### DIFF
--- a/packages/cached/test/cached-fs.spec.ts
+++ b/packages/cached/test/cached-fs.spec.ts
@@ -231,12 +231,12 @@ describe("createCachedFs", () => {
     expect(statSyncSpy.callCount).to.equal(2);
   });
 
-  const testProvider = async () => {
+  const testProvider = () => {
     const fs = createCachedFs(createMemoryFs());
     return {
       fs,
-      dispose: async () => undefined,
       tempDirectoryPath: fs.cwd(),
+      [Symbol.dispose]() {},
     };
   };
 

--- a/packages/memory/test/memory-fs.spec.ts
+++ b/packages/memory/test/memory-fs.spec.ts
@@ -4,11 +4,11 @@ import { syncBaseFsContract, asyncBaseFsContract, syncFsContract, asyncFsContrac
 import { createMemoryFs } from "@file-services/memory";
 
 describe("In-memory File System Implementation", () => {
-  const testProvider = async () => {
+  const testProvider = () => {
     return {
       fs: createMemoryFs(),
-      dispose: async () => undefined,
       tempDirectoryPath: "/",
+      [Symbol.dispose]() {},
     };
   };
 

--- a/packages/node/test/node-fs.nodespec.ts
+++ b/packages/node/test/node-fs.nodespec.ts
@@ -1,7 +1,7 @@
 import { createNodeFs } from "@file-services/node";
 import { asyncBaseFsContract, asyncFsContract, syncBaseFsContract, syncFsContract } from "@file-services/test-kit";
 import { expect } from "chai";
-import { createTempDirectory } from "create-temp-directory";
+import { createTempDirectorySync } from "create-temp-directory";
 import { platform } from "node:os";
 import { fileURLToPath } from "node:url";
 
@@ -10,15 +10,13 @@ describe("Node File System Implementation", function () {
 
   const fs = createNodeFs();
 
-  const testProvider = async () => {
-    const tempDirectory = await createTempDirectory("fs-test-");
+  const testProvider = () => {
+    const tempDirectory = createTempDirectorySync("fs-test-");
 
     return {
       fs,
-      dispose: async () => {
-        await tempDirectory.remove();
-      },
-      tempDirectoryPath: fs.realpathSync(tempDirectory.path),
+      tempDirectoryPath: tempDirectory.path,
+      [Symbol.dispose]: tempDirectory.remove,
     };
   };
 

--- a/packages/overlay/test/overlay.spec.ts
+++ b/packages/overlay/test/overlay.spec.ts
@@ -8,11 +8,11 @@ const sampleContent2 = `222`;
 const sampleContent3 = `333`;
 
 describe("overlay fs", () => {
-  const testProvider = async () => {
+  const testProvider = () => {
     return {
       fs: createOverlayFs(createMemoryFs(), createMemoryFs()),
-      dispose: async () => undefined,
       tempDirectoryPath: "/",
+      [Symbol.dispose]() {},
     };
   };
 

--- a/packages/test-kit/src/async-base-fs-contract.ts
+++ b/packages/test-kit/src/async-base-fs-contract.ts
@@ -9,15 +9,11 @@ chai.use(chaiAsPromised);
 const SAMPLE_CONTENT = "content";
 const DIFFERENT_CONTENT = "another content";
 
-export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBaseFileSystemAsync>>): void {
+export function asyncBaseFsContract(testProvider: () => ITestInput<IBaseFileSystemAsync>): void {
   describe("ASYNC file system contract", () => {
-    let testInput: ITestInput<IBaseFileSystemAsync>;
-
-    beforeEach(async () => (testInput = await testProvider()));
-    afterEach(async () => await testInput.dispose());
-
     describe("writing files", () => {
       it("can write a new file into an existing directory", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -34,6 +30,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("can write a binary file", async () => {
+        using testInput = testProvider();
         const {
           fs: {
             join,
@@ -56,6 +53,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("can overwrite an existing file", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -73,6 +71,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if writing a file to a non-existing directory", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -86,6 +85,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if writing a file to a path already pointing to a directory", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -101,6 +101,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if writing to a file without a name", async () => {
+        using testInput = testProvider();
         const {
           fs: {
             promises: { writeFile },
@@ -112,6 +113,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
     });
 
     it("stat size reflects the byte size of written content", async () => {
+      using testInput = testProvider();
       const {
         tempDirectoryPath,
         fs: {
@@ -140,6 +142,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
     describe("reading files", () => {
       it("can read the contents of a file", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -158,6 +161,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if reading a non-existing file", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -171,6 +175,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if reading a directory as a file", async () => {
+        using testInput = testProvider();
         const {
           fs: {
             promises: { readFile },
@@ -184,6 +189,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
     describe("removing files", () => {
       it("can remove files", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -200,6 +206,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if trying to remove a non-existing file", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -213,6 +220,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if trying to remove a directory as a file", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -230,6 +238,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
     describe("creating directories", () => {
       it("can create an empty directory inside an existing one", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -246,6 +255,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if creating in a path pointing to an existing directory", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -261,6 +271,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if creating in a path pointing to an existing file", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -276,6 +287,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if creating a directory inside a non-existing directory", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -289,6 +301,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if creating a directory inside of a file", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -306,6 +319,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
       describe("recursively", () => {
         it("can create an empty directory inside an existing one", async () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
           const directoryPath = fs.join(tempDirectoryPath, "new-dir");
 
@@ -316,6 +330,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         });
 
         it("creates parent directory chain when possible", async () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
           const directoryPath = fs.join(tempDirectoryPath, "missing", "also-missing", "new-dir");
 
@@ -326,6 +341,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         });
 
         it("succeeds if creating in a path pointing to an existing directory", async () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
           const directoryPath = fs.join(tempDirectoryPath, "dir");
           await fs.promises.mkdir(directoryPath);
@@ -334,6 +350,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         });
 
         it("fails if creating in a path pointing to an existing file", async () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
           const filePath = fs.join(tempDirectoryPath, "file");
           await fs.promises.writeFile(filePath, SAMPLE_CONTENT);
@@ -342,6 +359,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         });
 
         it("fails if creating a directory inside of a file", async () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
           const filePath = fs.join(tempDirectoryPath, "file");
           await fs.promises.writeFile(filePath, SAMPLE_CONTENT);
@@ -355,6 +373,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
     describe("listing directories", () => {
       it("can list an existing directory", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -376,6 +395,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("lists directory entries", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         await fs.promises.mkdir(fs.join(tempDirectoryPath, "dir"));
@@ -396,6 +416,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if listing a non-existing directory", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -409,6 +430,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if listing a path pointing to a file", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -426,6 +448,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
     describe("removing directories", () => {
       it("can remove an existing directory", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -442,6 +465,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if removing a non-empty directory", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -458,6 +482,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if removing a non-existing directory", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -471,6 +496,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if removing a path pointing to a file", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -488,6 +514,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
     describe("renaming directories and files", () => {
       it("moves a file", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -514,6 +541,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it(`throws if source path doesn't exist`, async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -528,6 +556,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it(`throws if the containing directory of the source path doesn't exist`, async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -542,6 +571,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it(`throws if destination containing path doesn't exist`, async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -558,6 +588,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("updates the parent directory of a renamed entry", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
@@ -578,6 +609,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
       describe("renaming directories", () => {
         it("allows renaming a complex directory structure to another destination", async () => {
+          using testInput = testProvider();
           const {
             tempDirectoryPath,
             fs: {
@@ -600,6 +632,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         });
 
         it(`allows renaming a directory over a non-existing directory`, async () => {
+          using testInput = testProvider();
           const {
             tempDirectoryPath,
             fs: {
@@ -616,6 +649,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
         });
 
         it(`allows renaming a directory over an empty directory`, async () => {
+          using testInput = testProvider();
           const {
             tempDirectoryPath,
             fs: {
@@ -636,6 +670,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
     });
 
     it("correctly exposes whether it is case sensitive", async () => {
+      using testInput = testProvider();
       const {
         tempDirectoryPath,
         fs: {
@@ -658,31 +693,22 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
     describe("copying files/directories", () => {
       const SOURCE_FILE_NAME = "file.txt";
-      let targetDirectoryPath: string;
-      let sourceFilePath: string;
 
-      beforeEach(async () => {
+      it("can copy file", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
             join,
-            promises: { writeFile, mkdir },
+            promises: { writeFile, mkdir, copyFile, readFile },
           },
         } = testInput;
-        targetDirectoryPath = join(tempDirectoryPath, "dir");
+        const targetDirectoryPath = join(tempDirectoryPath, "dir");
 
         await mkdir(targetDirectoryPath);
-        sourceFilePath = join(tempDirectoryPath, SOURCE_FILE_NAME);
+        const sourceFilePath = join(tempDirectoryPath, SOURCE_FILE_NAME);
         await writeFile(sourceFilePath, SAMPLE_CONTENT);
-      });
 
-      it("can copy file", async () => {
-        const {
-          fs: {
-            join,
-            promises: { copyFile, readFile },
-          },
-        } = testInput;
         const targetPath = join(targetDirectoryPath, SOURCE_FILE_NAME);
 
         await copyFile(sourceFilePath, targetPath);
@@ -691,13 +717,20 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if source does not exist", async () => {
+        using testInput = testProvider();
         const {
           tempDirectoryPath,
           fs: {
             join,
-            promises: { copyFile },
+            promises: { writeFile, mkdir, copyFile },
           },
         } = testInput;
+        const targetDirectoryPath = join(tempDirectoryPath, "dir");
+
+        await mkdir(targetDirectoryPath);
+        const sourceFilePath = join(tempDirectoryPath, SOURCE_FILE_NAME);
+        await writeFile(sourceFilePath, SAMPLE_CONTENT);
+
         const sourcePath = join(tempDirectoryPath, "nonExistingFileName.txt");
         const targetPath = join(targetDirectoryPath, SOURCE_FILE_NAME);
 
@@ -705,24 +738,40 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if target containing directory does not exist", async () => {
+        using testInput = testProvider();
         const {
+          tempDirectoryPath,
           fs: {
             join,
-            promises: { copyFile },
+            promises: { writeFile, mkdir, copyFile },
           },
         } = testInput;
+        const targetDirectoryPath = join(tempDirectoryPath, "dir");
+
+        await mkdir(targetDirectoryPath);
+        const sourceFilePath = join(tempDirectoryPath, SOURCE_FILE_NAME);
+        await writeFile(sourceFilePath, SAMPLE_CONTENT);
+
         const targetPath = join(targetDirectoryPath, "nonExistingDirectory", SOURCE_FILE_NAME);
 
         await expect(copyFile(sourceFilePath, targetPath)).to.be.rejectedWith("ENOENT");
       });
 
       it("overwrites destination file by default", async () => {
+        using testInput = testProvider();
         const {
+          tempDirectoryPath,
           fs: {
             join,
-            promises: { copyFile, readFile, writeFile },
+            promises: { writeFile, mkdir, copyFile, readFile },
           },
         } = testInput;
+        const targetDirectoryPath = join(tempDirectoryPath, "dir");
+
+        await mkdir(targetDirectoryPath);
+        const sourceFilePath = join(tempDirectoryPath, SOURCE_FILE_NAME);
+        await writeFile(sourceFilePath, SAMPLE_CONTENT);
+
         const targetPath = join(targetDirectoryPath, SOURCE_FILE_NAME);
 
         await writeFile(targetPath, "content to be overwritten");
@@ -732,12 +781,20 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("fails if destination exists and flag COPYFILE_EXCL passed", async () => {
+        using testInput = testProvider();
         const {
+          tempDirectoryPath,
           fs: {
             join,
-            promises: { copyFile, writeFile },
+            promises: { writeFile, mkdir, copyFile },
           },
         } = testInput;
+        const targetDirectoryPath = join(tempDirectoryPath, "dir");
+
+        await mkdir(targetDirectoryPath);
+        const sourceFilePath = join(tempDirectoryPath, SOURCE_FILE_NAME);
+        await writeFile(sourceFilePath, SAMPLE_CONTENT);
+
         const targetPath = join(targetDirectoryPath, SOURCE_FILE_NAME);
 
         await writeFile(targetPath, "content to be overwritten");
@@ -750,6 +807,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
 
     describe("removing directories and files", () => {
       it("removes an existing file, no matter the flags", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -773,6 +831,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it('removes an empty or populated directory when "recursive" is set', async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const emptyDirectoryPath = fs.join(tempDirectoryPath, "dir");
@@ -789,6 +848,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it('fails removing a directory when "recursive" is not set', async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const emptyDirectoryPath = fs.join(tempDirectoryPath, "dir");
@@ -805,6 +865,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it("throws removing a non-existing target", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const targetPath = fs.join(tempDirectoryPath, "target");
@@ -814,6 +875,7 @@ export function asyncBaseFsContract(testProvider: () => Promise<ITestInput<IBase
       });
 
       it('does not fail removing a non-existing target if "force" is set', async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const targetPath = fs.join(tempDirectoryPath, "target");

--- a/packages/test-kit/src/async-fs-contract.ts
+++ b/packages/test-kit/src/async-fs-contract.ts
@@ -8,15 +8,11 @@ chai.use(chaiAsPromised);
 
 const SAMPLE_CONTENT = "content";
 
-export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSystemAsync>>): void {
+export function asyncFsContract(testProvider: () => ITestInput<IFileSystemAsync>): void {
   describe("ASYNC file system contract", () => {
-    let testInput: ITestInput<IFileSystemAsync>;
-
-    beforeEach(async () => (testInput = await testProvider()));
-    afterEach(async () => await testInput.dispose());
-
     describe("fileExists", () => {
       it("returns true if path points to a file", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -27,6 +23,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
 
       it("returns false is path does not exist", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "non-existing-file");
@@ -35,6 +32,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
 
       it("returns false is path points to a directory", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "dir");
@@ -47,6 +45,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
     describe("directoryExists", () => {
       it("returns true if path points to a directory", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "dir");
@@ -57,6 +56,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
 
       it("returns false is path does not exist", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "non-existing-directory");
@@ -65,6 +65,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
 
       it("returns false is path points to a file", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -77,6 +78,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
     describe("readJsonFile", () => {
       it("parses contents of a json file and returns it", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file.json");
@@ -88,6 +90,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
 
       it("throws on file reading errors", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file.json");
@@ -96,6 +99,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
 
       it("throws on JSON parse errors", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file.json");
@@ -111,6 +115,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
     describe("findFiles", () => {
       it("finds all files recursively inside a directory", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "dir");
 
@@ -136,6 +141,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
 
       it("allows specifying a file filtering callback", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "dir");
 
@@ -160,6 +166,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
 
       it("allows specifying a directory filtering callback", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "dir");
 
@@ -185,6 +192,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
     describe("findClosestFile", () => {
       it("finds closest file in parent directory chain", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "dir");
 
@@ -214,6 +222,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
     describe("findFilesInAncestors", () => {
       it("finds files in parent directory chain", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "dir");
 
@@ -240,6 +249,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
     describe("copyDirectory", () => {
       it("copies a directory and its children", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const sourcePath = fs.join(tempDirectoryPath, "src");
         const destinationPath = fs.join(tempDirectoryPath, "dist");
@@ -274,6 +284,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
 
     describe("ensureDirectory", () => {
       it(`creates intermediate directories`, async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "animals", "mammals", "chiroptera");
 
@@ -283,6 +294,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
 
       it(`succeeds if directory already exists`, async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "some-directory");
         await fs.promises.mkdir(directoryPath);
@@ -291,6 +303,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
 
       it(`throws when target points to an existing file`, async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const filePath = fs.join(tempDirectoryPath, "bat.txt");
         await fs.promises.writeFile(filePath, "🦇");
@@ -299,6 +312,7 @@ export function asyncFsContract(testProvider: () => Promise<ITestInput<IFileSyst
       });
 
       it(`throws when attempting to create a directory inside of a file`, async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const filePath = fs.join(tempDirectoryPath, "bat.txt");
         await fs.promises.writeFile(filePath, "🦇");

--- a/packages/test-kit/src/sync-base-fs-contract.ts
+++ b/packages/test-kit/src/sync-base-fs-contract.ts
@@ -1,4 +1,4 @@
-import { FileSystemConstants, type FSWatcher, type IBaseFileSystemSync } from "@file-services/types";
+import { FileSystemConstants, type IBaseFileSystemSync } from "@file-services/types";
 import { expect } from "chai";
 import { sleep, waitFor } from "promise-assist";
 import type { ITestInput } from "./types.js";
@@ -7,17 +7,13 @@ const SAMPLE_CONTENT = "content";
 const DIFFERENT_CONTENT = "another content";
 
 export function syncBaseFsContract(
-  testProvider: () => Promise<ITestInput<IBaseFileSystemSync>>,
+  testProvider: () => ITestInput<IBaseFileSystemSync>,
   supportsRecursiveWatch = true,
 ): void {
   describe("SYNC file system contract", () => {
-    let testInput: ITestInput<IBaseFileSystemSync>;
-
-    beforeEach(async () => (testInput = await testProvider()));
-    afterEach(async () => await testInput.dispose());
-
     describe("writing files", () => {
       it("can write a new file into an existing directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -29,6 +25,7 @@ export function syncBaseFsContract(
       });
 
       it("can write a binary file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -45,6 +42,7 @@ export function syncBaseFsContract(
       });
 
       it("can overwrite an existing file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -57,6 +55,7 @@ export function syncBaseFsContract(
       });
 
       it("fails if writing a file to a non-existing directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "missing-dir", "file");
@@ -67,6 +66,7 @@ export function syncBaseFsContract(
       });
 
       it("fails if writing a file to a path already pointing to a directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "dir");
@@ -78,12 +78,14 @@ export function syncBaseFsContract(
       });
 
       it("fails if writing to a file without a name", () => {
+        using testInput = testProvider();
         const { fs } = testInput;
         expect(() => fs.writeFileSync("", SAMPLE_CONTENT)).to.throw("ENOENT");
       });
     });
 
     it("stat size reflects the byte size of written content", () => {
+      using testInput = testProvider();
       const { fs, tempDirectoryPath } = testInput;
       const filePath = fs.join(tempDirectoryPath, "file");
       const SAMPLE_CONTENT = "🚀";
@@ -106,6 +108,7 @@ export function syncBaseFsContract(
 
     describe("reading files", () => {
       it("can read the contents of a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const firstFilePath = fs.join(tempDirectoryPath, "first-file");
         const secondFilePath = fs.join(tempDirectoryPath, "second-file");
@@ -119,12 +122,14 @@ export function syncBaseFsContract(
       });
 
       it("fails if reading a non-existing file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const filePath = fs.join(tempDirectoryPath, "missing-file");
         expect(() => fs.readFileSync(filePath, "utf8")).to.throw("ENOENT");
       });
 
       it("fails if reading a directory as a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         expect(() => fs.readFileSync(tempDirectoryPath, "utf8")).to.throw("EISDIR");
       });
@@ -132,6 +137,7 @@ export function syncBaseFsContract(
 
     describe("removing files", () => {
       it("can remove files", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const filePath = fs.join(tempDirectoryPath, "file");
         fs.writeFileSync(filePath, SAMPLE_CONTENT);
@@ -140,12 +146,14 @@ export function syncBaseFsContract(
       });
 
       it("fails if trying to remove a non-existing file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const filePath = fs.join(tempDirectoryPath, "missing-file");
         expect(() => fs.unlinkSync(filePath)).to.throw("ENOENT");
       });
 
       it("fails if trying to remove a directory as a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "dir");
         fs.mkdirSync(directoryPath);
@@ -157,20 +165,13 @@ export function syncBaseFsContract(
       const timeout = 5_000;
       this.timeout(timeout * 1.5);
 
-      const openWatchers = new Set<FSWatcher>();
-      afterEach(() => {
-        for (const watcher of openWatchers) {
-          watcher.close();
-        }
-        openWatchers.clear();
-      });
-
       it("emits 'change' event when a watched file changes", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const testFilePath = fs.join(tempDirectoryPath, "test-file");
         fs.writeFileSync(testFilePath, SAMPLE_CONTENT);
         const watcher = fs.watch(testFilePath);
-        openWatchers.add(watcher);
+        using _ = { [Symbol.dispose]: () => watcher.close() };
 
         const watchEvents: Array<{ type: string; relativePath: string }> = [];
         watcher.on("change", (type, relativePath) => watchEvents.push({ type, relativePath }));
@@ -186,11 +187,12 @@ export function syncBaseFsContract(
       });
 
       it("emits 'rename' event when a watched file is removed", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const testFilePath = fs.join(tempDirectoryPath, "test-file");
         fs.writeFileSync(testFilePath, SAMPLE_CONTENT);
         const watcher = fs.watch(testFilePath);
-        openWatchers.add(watcher);
+        using _ = { [Symbol.dispose]: () => watcher.close() };
 
         const watchEvents: Array<{ type: string; relativePath: string }> = [];
         watcher.on("change", (type, relativePath) => watchEvents.push({ type, relativePath }));
@@ -206,11 +208,12 @@ export function syncBaseFsContract(
       });
 
       it("emits 'change' event when a file is changed in a watched directory", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const testFilePath = fs.join(tempDirectoryPath, "test-file");
         fs.writeFileSync(testFilePath, SAMPLE_CONTENT);
         const watcher = fs.watch(tempDirectoryPath);
-        openWatchers.add(watcher);
+        using _ = { [Symbol.dispose]: () => watcher.close() };
 
         const watchEvents: Array<{ type: string; relativePath: string }> = [];
         watcher.on("change", (type, relativePath) => watchEvents.push({ type, relativePath }));
@@ -228,6 +231,7 @@ export function syncBaseFsContract(
 
       if (supportsRecursiveWatch) {
         it("emits 'change' event when a deeply nested file is changed in a watched directory (when recursive)", async () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
           const testFilePath = fs.join(tempDirectoryPath, "test-file");
           const nestedDirectoryPath = fs.join(tempDirectoryPath, "nested");
@@ -237,7 +241,7 @@ export function syncBaseFsContract(
           fs.writeFileSync(deeplyNestedPath, SAMPLE_CONTENT);
 
           const watcher = fs.watch(tempDirectoryPath, { recursive: true });
-          openWatchers.add(watcher);
+          using _ = { [Symbol.dispose]: () => watcher.close() };
 
           // recursive watcher needs some time to set up. don't seem to have event to wait for.
           await sleep(500);
@@ -258,11 +262,12 @@ export function syncBaseFsContract(
       }
 
       it("emits 'rename' event when a file is removed in a watched directory", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const testFilePath = fs.join(tempDirectoryPath, "test-file");
         fs.writeFileSync(testFilePath, SAMPLE_CONTENT);
         const watcher = fs.watch(tempDirectoryPath);
-        openWatchers.add(watcher);
+        using _ = { [Symbol.dispose]: () => watcher.close() };
 
         const watchEvents: Array<{ type: string; relativePath: string }> = [];
         watcher.on("change", (type, relativePath) => watchEvents.push({ type, relativePath }));
@@ -272,10 +277,11 @@ export function syncBaseFsContract(
       });
 
       it("emits 'rename' event when a file is added in a watched directory", async () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const testFilePath = fs.join(tempDirectoryPath, "test-file");
         const watcher = fs.watch(tempDirectoryPath);
-        openWatchers.add(watcher);
+        using _ = { [Symbol.dispose]: () => watcher.close() };
 
         const watchEvents: Array<{ type: string; relativePath: string }> = [];
         watcher.on("change", (type, relativePath) => watchEvents.push({ type, relativePath }));
@@ -293,6 +299,7 @@ export function syncBaseFsContract(
 
     describe("creating directories", () => {
       it("can create an empty directory inside an existing one", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "new-dir");
@@ -304,6 +311,7 @@ export function syncBaseFsContract(
       });
 
       it("fails if creating in a path pointing to an existing directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "dir");
@@ -315,6 +323,7 @@ export function syncBaseFsContract(
       });
 
       it("fails if creating in a path pointing to an existing file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -326,6 +335,7 @@ export function syncBaseFsContract(
       });
 
       it("fails if creating a directory inside a non-existing directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "outer", "inner");
@@ -336,6 +346,7 @@ export function syncBaseFsContract(
       });
 
       it("fails if creating a directory inside of a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -348,6 +359,7 @@ export function syncBaseFsContract(
 
       describe("recursively", () => {
         it("can create an empty directory inside an existing one", () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
           const directoryPath = fs.join(tempDirectoryPath, "new-dir");
 
@@ -358,6 +370,7 @@ export function syncBaseFsContract(
         });
 
         it("creates parent directory chain when possible", () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
           const directoryPath = fs.join(tempDirectoryPath, "missing", "also-missing", "new-dir");
 
@@ -368,6 +381,7 @@ export function syncBaseFsContract(
         });
 
         it("succeeds if creating in a path pointing to an existing directory", () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
           const directoryPath = fs.join(tempDirectoryPath, "dir");
           fs.mkdirSync(directoryPath);
@@ -376,6 +390,7 @@ export function syncBaseFsContract(
         });
 
         it("fails if creating in a path pointing to an existing file", () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
           const filePath = fs.join(tempDirectoryPath, "file");
           fs.writeFileSync(filePath, SAMPLE_CONTENT);
@@ -384,6 +399,7 @@ export function syncBaseFsContract(
         });
 
         it("fails if creating a directory inside of a file", () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
           const filePath = fs.join(tempDirectoryPath, "file");
           fs.writeFileSync(filePath, SAMPLE_CONTENT);
@@ -395,6 +411,7 @@ export function syncBaseFsContract(
 
     describe("listing directories", () => {
       it("can list an existing directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "dir");
@@ -411,6 +428,7 @@ export function syncBaseFsContract(
       });
 
       it("lists directory entries", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         fs.mkdirSync(fs.join(tempDirectoryPath, "dir"));
@@ -431,6 +449,7 @@ export function syncBaseFsContract(
       });
 
       it("fails if listing a non-existing directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "missing-dir");
@@ -441,6 +460,7 @@ export function syncBaseFsContract(
       });
 
       it("fails if listing a path pointing to a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -454,6 +474,7 @@ export function syncBaseFsContract(
 
     describe("removing directories", () => {
       it("can remove an existing directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "dir");
@@ -465,6 +486,7 @@ export function syncBaseFsContract(
       });
 
       it("fails if removing a non-empty directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "dir");
@@ -477,6 +499,7 @@ export function syncBaseFsContract(
       });
 
       it("fails if removing a non-existing directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "missing-dir");
@@ -487,6 +510,7 @@ export function syncBaseFsContract(
       });
 
       it("fails if removing a path pointing to a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -500,6 +524,7 @@ export function syncBaseFsContract(
 
     describe("renaming directories and files", () => {
       it("moves a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const sourcePath = fs.join(tempDirectoryPath, "file");
@@ -517,6 +542,7 @@ export function syncBaseFsContract(
       });
 
       it("updates mtime", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const sourcePath = fs.join(tempDirectoryPath, "file");
@@ -530,6 +556,7 @@ export function syncBaseFsContract(
       });
 
       it(`throws if source path doesn't exist`, () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const sourcePath = fs.join(tempDirectoryPath, "file");
@@ -538,6 +565,7 @@ export function syncBaseFsContract(
       });
 
       it(`throws if the containing directory of the source path doesn't exist`, () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const sourcePath = fs.join(tempDirectoryPath, "unicorn", "file");
@@ -546,6 +574,7 @@ export function syncBaseFsContract(
       });
 
       it(`throws if destination containing path doesn't exist`, () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const sourcePath = fs.join(tempDirectoryPath, "file");
@@ -556,6 +585,7 @@ export function syncBaseFsContract(
       });
 
       it("updates the parent directory of a renamed entry", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const sourcePath = fs.join(tempDirectoryPath, "sourceDir");
@@ -571,6 +601,7 @@ export function syncBaseFsContract(
 
       describe("renaming directories", () => {
         it("allows renaming a complex directory structure to another destination", () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
 
           const sourcePath = fs.join(tempDirectoryPath, "dir");
@@ -588,6 +619,7 @@ export function syncBaseFsContract(
         });
 
         it(`allows renaming a directory over a non-existing directory`, () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
 
           const sourcePath = fs.join(tempDirectoryPath, "sourceDir");
@@ -599,6 +631,7 @@ export function syncBaseFsContract(
         });
 
         it(`allows renaming a directory over an empty directory`, () => {
+          using testInput = testProvider();
           const { fs, tempDirectoryPath } = testInput;
 
           const sourcePath = fs.join(tempDirectoryPath, "sourceDir");
@@ -614,6 +647,7 @@ export function syncBaseFsContract(
     });
 
     it("correctly exposes whether it is case sensitive", () => {
+      using testInput = testProvider();
       const { fs, tempDirectoryPath } = testInput;
 
       const filePath = fs.join(tempDirectoryPath, "file");
@@ -630,40 +664,57 @@ export function syncBaseFsContract(
 
     describe("copying files/directories", () => {
       const SOURCE_FILE_NAME = "file.txt";
-      let targetDirectoryPath: string;
-      let sourceFilePath: string;
-
-      beforeEach(() => {
-        const { fs, tempDirectoryPath } = testInput;
-
-        targetDirectoryPath = fs.join(tempDirectoryPath, "dir");
-        fs.mkdirSync(targetDirectoryPath);
-        sourceFilePath = fs.join(tempDirectoryPath, SOURCE_FILE_NAME);
-        fs.writeFileSync(sourceFilePath, SAMPLE_CONTENT);
-      });
 
       it("can copy file", () => {
-        const { fs } = testInput;
+        using testInput = testProvider();
+        const { fs, tempDirectoryPath } = testInput;
+
+        const targetDirectoryPath = fs.join(tempDirectoryPath, "dir");
+        fs.mkdirSync(targetDirectoryPath);
+        const sourceFilePath = fs.join(tempDirectoryPath, SOURCE_FILE_NAME);
+        fs.writeFileSync(sourceFilePath, SAMPLE_CONTENT);
+
         const targetPath = fs.join(targetDirectoryPath, SOURCE_FILE_NAME);
         fs.copyFileSync(sourceFilePath, targetPath);
         expect(fs.readFileSync(targetPath, "utf8")).to.be.eql(SAMPLE_CONTENT);
       });
 
       it("fails if source does not exist", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
+
+        const targetDirectoryPath = fs.join(tempDirectoryPath, "dir");
+        fs.mkdirSync(targetDirectoryPath);
+        const sourceFilePath = fs.join(tempDirectoryPath, SOURCE_FILE_NAME);
+        fs.writeFileSync(sourceFilePath, SAMPLE_CONTENT);
+
         const sourcePath = fs.join(tempDirectoryPath, "nonExistingFileName.txt");
         const targetPath = fs.join(targetDirectoryPath, SOURCE_FILE_NAME);
         expect(() => fs.copyFileSync(sourcePath, targetPath)).to.throw("ENOENT");
       });
 
       it("fails if target containing directory does not exist", () => {
-        const { fs } = testInput;
+        using testInput = testProvider();
+        const { fs, tempDirectoryPath } = testInput;
+
+        const targetDirectoryPath = fs.join(tempDirectoryPath, "dir");
+        fs.mkdirSync(targetDirectoryPath);
+        const sourceFilePath = fs.join(tempDirectoryPath, SOURCE_FILE_NAME);
+        fs.writeFileSync(sourceFilePath, SAMPLE_CONTENT);
+
         const targetPath = fs.join(targetDirectoryPath, "nonExistingDirectory", SOURCE_FILE_NAME);
         expect(() => fs.copyFileSync(sourceFilePath, targetPath)).to.throw("ENOENT");
       });
 
       it("overwrites destination file by default", () => {
-        const { fs } = testInput;
+        using testInput = testProvider();
+        const { fs, tempDirectoryPath } = testInput;
+
+        const targetDirectoryPath = fs.join(tempDirectoryPath, "dir");
+        fs.mkdirSync(targetDirectoryPath);
+        const sourceFilePath = fs.join(tempDirectoryPath, SOURCE_FILE_NAME);
+        fs.writeFileSync(sourceFilePath, SAMPLE_CONTENT);
+
         const targetPath = fs.join(targetDirectoryPath, SOURCE_FILE_NAME);
         fs.writeFileSync(targetPath, "content to be overwritten");
         fs.copyFileSync(sourceFilePath, targetPath);
@@ -671,7 +722,14 @@ export function syncBaseFsContract(
       });
 
       it("fails if destination exists and flag COPYFILE_EXCL passed", () => {
-        const { fs } = testInput;
+        using testInput = testProvider();
+        const { fs, tempDirectoryPath } = testInput;
+
+        const targetDirectoryPath = fs.join(tempDirectoryPath, "dir");
+        fs.mkdirSync(targetDirectoryPath);
+        const sourceFilePath = fs.join(tempDirectoryPath, SOURCE_FILE_NAME);
+        fs.writeFileSync(sourceFilePath, SAMPLE_CONTENT);
+
         const targetPath = fs.join(targetDirectoryPath, SOURCE_FILE_NAME);
         fs.writeFileSync(targetPath, "content to be overwritten");
         expect(() => fs.copyFileSync(sourceFilePath, targetPath, FileSystemConstants.COPYFILE_EXCL)).to.throw("EEXIST");
@@ -683,6 +741,7 @@ export function syncBaseFsContract(
       const LINK_NAME = "link";
 
       it("creates a link to a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const targetPath = fs.join(tempDirectoryPath, TARGET_NAME);
         fs.writeFileSync(targetPath, SAMPLE_CONTENT);
@@ -701,6 +760,7 @@ export function syncBaseFsContract(
       });
 
       it("creates a link to a directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const targetPath = fs.join(tempDirectoryPath, TARGET_NAME);
         const innerDirectoryPath = fs.join(targetPath, "inner-dir");
@@ -726,6 +786,7 @@ export function syncBaseFsContract(
       });
 
       it("creates a link to a non existing path", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const targetPath = fs.join(tempDirectoryPath, TARGET_NAME);
 
@@ -741,6 +802,7 @@ export function syncBaseFsContract(
       });
 
       it("picks up a target created after the link", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const targetPath = fs.join(tempDirectoryPath, TARGET_NAME);
 
@@ -753,6 +815,7 @@ export function syncBaseFsContract(
       });
 
       it("provides link stats even if target is deleted", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const targetPath = fs.join(tempDirectoryPath, TARGET_NAME);
         const linkPath = fs.join(tempDirectoryPath, LINK_NAME);
@@ -766,6 +829,7 @@ export function syncBaseFsContract(
       });
 
       it("resolves the real path of a link", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const targetPath = fs.join(tempDirectoryPath, TARGET_NAME);
         fs.writeFileSync(targetPath, SAMPLE_CONTENT);
@@ -780,6 +844,7 @@ export function syncBaseFsContract(
       });
 
       it("resolves the real path of a file inside a linked directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const targetDirectoryPath = fs.join(tempDirectoryPath, "target-dir");
@@ -802,6 +867,7 @@ export function syncBaseFsContract(
       });
 
       it("keeps relative links relative", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const targetPath = fs.join(tempDirectoryPath, TARGET_NAME);
         fs.writeFileSync(targetPath, SAMPLE_CONTENT);
@@ -819,6 +885,7 @@ export function syncBaseFsContract(
       });
 
       it("fails when link parent directory is missing", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const targetFilePath = fs.join(tempDirectoryPath, TARGET_NAME);
         fs.writeFileSync(targetFilePath, SAMPLE_CONTENT);
@@ -828,6 +895,7 @@ export function syncBaseFsContract(
       });
 
       it("fails creating a link over an existing file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const targetPath = fs.join(tempDirectoryPath, TARGET_NAME);
         fs.writeFileSync(targetPath, SAMPLE_CONTENT);
@@ -839,6 +907,7 @@ export function syncBaseFsContract(
       });
 
       it("fails creating a link over an existing directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const targetPath = fs.join(tempDirectoryPath, TARGET_NAME);
         const linkPath = fs.join(tempDirectoryPath, LINK_NAME);
@@ -852,6 +921,7 @@ export function syncBaseFsContract(
 
     describe("removing directories and files", () => {
       it("removes an existing file, no matter the flags", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -875,6 +945,7 @@ export function syncBaseFsContract(
       });
 
       it('removes an empty or populated directory when "recursive" is set', () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const emptyDirectoryPath = fs.join(tempDirectoryPath, "dir");
@@ -891,6 +962,7 @@ export function syncBaseFsContract(
       });
 
       it('fails removing a directory when "recursive" is not set', () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const emptyDirectoryPath = fs.join(tempDirectoryPath, "dir");
@@ -907,6 +979,7 @@ export function syncBaseFsContract(
       });
 
       it("throws removing a non-existing target", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const targetPath = fs.join(tempDirectoryPath, "target");
@@ -916,6 +989,7 @@ export function syncBaseFsContract(
       });
 
       it('does not fail removing a non-existing target if "force" is set', () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const targetPath = fs.join(tempDirectoryPath, "target");

--- a/packages/test-kit/src/sync-fs-contract.ts
+++ b/packages/test-kit/src/sync-fs-contract.ts
@@ -4,15 +4,11 @@ import type { ITestInput } from "./types.js";
 
 const SAMPLE_CONTENT = "content";
 
-export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSystemSync>>): void {
+export function syncFsContract(testProvider: () => ITestInput<IFileSystemSync>): void {
   describe("SYNC file system contract", () => {
-    let testInput: ITestInput<IFileSystemSync>;
-
-    beforeEach(async () => (testInput = await testProvider()));
-    afterEach(async () => await testInput.dispose());
-
     describe("fileExistsSync", () => {
       it("returns true if path points to a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -23,6 +19,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("returns false if path does not exist", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "non-existing-file");
@@ -31,6 +28,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("returns false if path points to a directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "dir");
@@ -41,6 +39,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("returns false if parent path points to a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -51,6 +50,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("returns false even if parent path does not exist", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "missing-parent", "non-existing-file");
@@ -61,6 +61,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
 
     describe("directoryExistsSync", () => {
       it("returns true if path points to a directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const directoryPath = fs.join(tempDirectoryPath, "dir");
@@ -71,6 +72,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("returns false if path does not exist", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "non-existing-directory");
@@ -79,6 +81,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("returns false if path points to a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -89,6 +92,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("returns false if parent path points to a file", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file");
@@ -99,6 +103,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("returns false if parent path does not exist", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "missing-parent", "non-existing-directory");
@@ -109,6 +114,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
 
     describe("readJsonFileSync", () => {
       it("parses contents of a json file and returns it", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file.json");
@@ -120,6 +126,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("throws on file reading errors", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file.json");
@@ -128,6 +135,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("throws on JSON parse errors", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
 
         const filePath = fs.join(tempDirectoryPath, "file.json");
@@ -143,6 +151,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
 
     describe("findFilesSync", () => {
       it("finds all files recursively inside a directory", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "dir");
 
@@ -168,6 +177,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("allows specifying a file filtering callback", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "dir");
 
@@ -192,6 +202,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("allows specifying a directory filtering callback", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "dir");
 
@@ -219,6 +230,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
 
     describe("findClosestFileSync", () => {
       it("finds closest file in parent directory chain", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "dir");
 
@@ -248,6 +260,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
 
     describe("findFilesInAncestorsSync", () => {
       it("finds files in parent directory chain", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "dir");
 
@@ -274,6 +287,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
 
     describe("copyDirectorySync", () => {
       it("copies a directory and its children", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const sourcePath = fs.join(tempDirectoryPath, "src");
         const destinationPath = fs.join(tempDirectoryPath, "dist");
@@ -306,6 +320,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
 
     describe("ensureDirectorySync", () => {
       it(`creates intermediate directories`, () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "animals", "mammals", "chiroptera");
 
@@ -315,6 +330,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it(`succeeds if directory already exists`, () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "some-directory");
         fs.mkdirSync(directoryPath);
@@ -323,6 +339,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it(`throws when target points to an existing file`, () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const filePath = fs.join(tempDirectoryPath, "bat.txt");
         fs.writeFileSync(filePath, "🦇");
@@ -331,6 +348,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it(`throws when attempting to create a directory inside of a file`, () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const filePath = fs.join(tempDirectoryPath, "bat.txt");
         fs.writeFileSync(filePath, "🦇");
@@ -340,6 +358,7 @@ export function syncFsContract(testProvider: () => Promise<ITestInput<IFileSyste
       });
 
       it("handles special paths gracefully", () => {
+        using testInput = testProvider();
         const { fs, tempDirectoryPath } = testInput;
         const directoryPath = fs.join(tempDirectoryPath, "some-directory");
         fs.mkdirSync(directoryPath);

--- a/packages/test-kit/src/types.ts
+++ b/packages/test-kit/src/types.ts
@@ -15,5 +15,5 @@ export interface ITestInput<T> {
   /**
    * Post-test cleanup
    */
-  dispose(): Promise<void>;
+  [Symbol.dispose](): void;
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2021",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["es2021", "dom"],                            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["es2021", "dom", "esnext.disposable"],       /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "libReplacement": true,                           /* Enable lib replacement. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
- make use of "using" statements
- remove beforeEach/afterEach